### PR TITLE
feat(audio): add user-facing audio analysis surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.3.1-beta.1] - 2026-05-05
+
 ### Added
+
+- Audio file analysis support via a new `POST /api/analyze/audio` REST endpoint — upload an audio file and get back chord events and key estimates, with optional time segment parameters for analyzing specific portions (#31)
+- `[audio]` optional extra (`pip install harmonic-analysis[audio]`) enabling audio-to-harmony analysis powered by librosa and soundfile; the core library remains lightweight for users who don't need audio (#31)
+- Comprehensive audio analysis documentation covering quickstart tutorial, how-to guide, API reference, and architectural internals (#31)
 
 - **Audio analysis subpackage** (`harmonic_analysis.audio`): ported Krumhansl-Schmuckler key detection,
   V-I cadence detection, and harmonic region classification into a new private subpackage with zero

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ pip install harmonic-analysis[educational]
 pip install harmonic-analysis[music21]
 
 # Multiple features
-pip install harmonic-analysis[educational,music21]
+pip install harmonic-analysis[educational,music21,audio]
 ```
 
 **Note:** The REST API is now part of the demo project (`demo/backend/rest_api/`) rather than the core library. See the [REST API Demo](#-rest-api-demo-new) section below for setup instructions.
@@ -231,6 +231,15 @@ from harmonic_analysis.integrations import Music21Adapter
 adapter = Music21Adapter()
 ```
 
+**Audio Analysis** (Analyze WAV/MP3 files for key, chords, and cadences):
+```bash
+pip install harmonic-analysis[audio]
+```
+```python
+from harmonic_analysis import analyze_audio_async
+result = await analyze_audio_async("path/to/file.wav")
+```
+
 #### 🔒 **Internal Components** (Not Exported)
 
 These are used internally by the library but not exposed in the public API:
@@ -269,6 +278,11 @@ else:
 - **[How-to Guides](docs/how-to/)** - Task-specific solutions
 - **[API Guide](docs/API_GUIDE.md)** - Comprehensive API documentation
 - **[Development Guide](docs/DEVELOPMENT.md)** - Contributing and development workflow
+
+### Audio Analysis (Optional)
+
+- **[Audio Quick Start](docs/tutorials/audio-quickstart.md)** - 5-minute hands-on tutorial for analyzing audio files
+- **[How to Analyze Audio](docs/how-to/audio-analysis.md)** - Task-oriented guide with toolkit migration recipes
 
 ## 📁 Project Structure
 

--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -5,6 +5,31 @@ the good stuff — what you can actually *do* now — lives here.
 
 ---
 
+## [0.3.1-beta.1] - 2026-05-05
+
+### ✨ New Things You Can Do
+
+🎵 **Audio Analysis**: You can now analyze audio files directly — just `POST` a file to
+`/api/analyze/audio` and get back chord events and key estimates. No more transcribing by hand
+before running harmonic analysis; drop in a WAV (or MP3/OGG with ffmpeg) and let the library
+do the listening.
+
+📦 **Opt into audio without bloating your install.** Audio dependencies (librosa, soundfile) are
+now tucked behind an optional extra: `pip install harmonic-analysis[audio]`. If you don't need
+audio analysis, your install stays lean — `import harmonic_analysis` works exactly as before,
+no extra baggage.
+
+⏱️ **Analyze just the part you care about.** The audio endpoint accepts optional `start` and `end`
+time parameters so you can zoom in on a specific section of a long recording instead of processing
+the whole file.
+
+### 📚 New Documentation
+
+Full audio analysis docs are now live: quickstart tutorial, how-to guide, API reference, and an
+internals explainer covering how the chroma extraction and key detection pipeline actually works.
+
+---
+
 ## [0.3.0] - 2026-05-04
 
 ### ✨ New Things You Can Do

--- a/demo/backend/rest_api/models.py
+++ b/demo/backend/rest_api/models.py
@@ -185,3 +185,80 @@ class ProfileResponse(BaseModel):
     profiles: List[ProfileInfo] = Field(
         description="List of available analysis profiles"
     )
+
+
+# Audio analysis models — documentation/parity guard only.
+# The route returns Dict[str, Any] (DD3), not a typed response_model.
+# These exist so the shape is declared once and can be validated in tests.
+
+
+class ChordEventModel(BaseModel):
+    """A single timestamped chord event from the audio pipeline."""
+
+    start_time: float = Field(description="Start time in seconds")
+    end_time: float = Field(description="End time in seconds")
+    chord_label: str = Field(description="Detected chord symbol (e.g. 'C', 'Am')")
+    confidence: float = Field(description="Cosine similarity confidence 0-1")
+    is_diatonic: bool = Field(
+        description="Whether the chord belongs to the estimated key"
+    )
+
+
+class _KeyInfoModel(BaseModel):
+    """Key estimation subset — excludes diatonic_pitch_classes (frozenset, not JSON-safe)."""
+
+    tonic: str
+    mode: str
+    key_signature: str
+    confidence: float
+
+
+class _LocalKeyModel(_KeyInfoModel):
+    """Key info plus region classification for the local key.
+
+    The route flattens KeyInfo + RegionInfo into one dict under ``local``.
+    This model reflects that combined shape so the OpenAPI schema stays honest.
+    """
+
+    region_type: str
+    region_confidence: float
+    borrowed_tones: List[str] = Field(default_factory=list)
+
+
+class _RegionModel(BaseModel):
+    """Region classification result."""
+
+    type: str
+    confidence: float
+    borrowed_tones: List[str] = Field(default_factory=list)
+
+
+class _AnalysisModel(BaseModel):
+    """Cadence detection summary."""
+
+    cadence_detected: bool
+    cadence_strength: float
+
+
+class _SegmentModel(BaseModel):
+    """Analyzed time window."""
+
+    start: float
+    end: float
+
+
+class AudioAnalysisResponse(BaseModel):
+    """Shape of the JSON returned by POST /api/analyze/audio.
+
+    Mirrors the dict the route builds manually. Does NOT include
+    ``diatonic_pitch_classes`` (frozenset is not JSON-serializable)
+    or ``visuals`` (not produced by the library).
+    """
+
+    global_key: _KeyInfoModel = Field(alias="global")
+    local_key: _LocalKeyModel = Field(alias="local")
+    analysis: _AnalysisModel
+    chord_progression: List[ChordEventModel]
+    segment: _SegmentModel
+
+    model_config = {"populate_by_name": True}

--- a/demo/backend/rest_api/routes.py
+++ b/demo/backend/rest_api/routes.py
@@ -413,6 +413,109 @@ async def analyze_file_endpoint(
                 pass  # Best effort cleanup
 
 
+# Route: Audio file analysis
+@router.post("/api/analyze/audio")
+async def analyze_audio_endpoint(
+    file: UploadFile = File(...),
+    start: Optional[float] = Form(None),
+    end: Optional[float] = Form(None),
+) -> Dict[str, Any]:
+    """
+    Analyze an audio file (WAV, MP3, etc.) for key, chords, and cadences.
+
+    Opening move: Accept audio upload, run the library's audio pipeline.
+    Main play: Build a JSON-safe response dict (no frozensets allowed).
+    Victory lap: Return key estimation, chord progression, and cadence info.
+    """
+    # Import guard — audio deps are optional; fail loudly with install hint
+    try:
+        from harmonic_analysis import AudioImportError, analyze_audio_async
+    except ImportError:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Audio analysis is not available. Install the audio extra: "
+                "pip install harmonic-analysis[audio]"
+            ),
+        )
+
+    # Opening move: validate we got a file
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="No filename provided")
+
+    # Main play: save uploaded file to temp location (same pattern as /analyze/file)
+    temp_dir = tempfile.gettempdir()
+    temp_file_path = os.path.join(temp_dir, f"audio_{file.filename}")
+
+    try:
+        contents = await file.read()
+        with open(temp_file_path, "wb") as f:
+            f.write(contents)
+
+        # Build segment tuple if the caller specified a window
+        segment = (start, end) if start is not None else None
+
+        result = await analyze_audio_async(temp_file_path, segment=segment)
+
+        # Victory lap: build the response dict MANUALLY.
+        # Never use asdict() here — KeyInfo.diatonic_pitch_classes is a
+        # frozenset and will 500 the entire response. Ask me how I know.
+        return {
+            "global": {
+                "tonic": result.global_key.tonic,
+                "mode": result.global_key.mode,
+                "key_signature": result.global_key.key_signature,
+                "confidence": result.global_key.confidence,
+            },
+            "local": {
+                "tonic": result.local_key.tonic,
+                "mode": result.local_key.mode,
+                "key_signature": result.local_key.key_signature,
+                "confidence": result.local_key.confidence,
+                "region_type": result.region.type,
+                "region_confidence": result.region.confidence,
+                "borrowed_tones": result.region.borrowed,
+            },
+            "analysis": {
+                "cadence_detected": result.cadences.detected,
+                "cadence_strength": result.cadences.strength,
+            },
+            "chord_progression": [
+                {
+                    "start_time": c.start_time,
+                    "end_time": c.end_time,
+                    "chord_label": c.chord_label,
+                    "confidence": c.confidence,
+                    "is_diatonic": c.is_diatonic,
+                }
+                for c in result.chords
+            ],
+            "segment": {
+                "start": result.segment_start,
+                "end": result.segment_end,
+            },
+        }
+
+    except AudioImportError:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Audio analysis dependencies not installed. "
+                "Run: pip install harmonic-analysis[audio]"
+            ),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Audio analysis failed: {exc}")
+    finally:
+        if os.path.exists(temp_file_path):
+            try:
+                os.remove(temp_file_path)
+            except Exception:
+                pass  # Best effort cleanup
+
+
 # Route: Glossary lookup
 @router.get("/api/glossary/{term}")
 def glossary_lookup(term: str) -> Dict[str, Any]:

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -6,3 +6,5 @@ uvicorn[standard]>=0.24.0
 python-multipart>=0.0.6
 pydantic>=2.0.0
 music21
+librosa>=0.10.1
+soundfile>=0.13.1

--- a/docs/explanation/audio-analysis-internals.md
+++ b/docs/explanation/audio-analysis-internals.md
@@ -1,0 +1,87 @@
+# Audio Analysis Internals
+
+Design rationale for the audio analysis pipeline. This document explains *why* the pipeline makes the choices it does, not *how* to use it (see [How to Analyze Audio](../how-to/audio-analysis.md)) or *what* the API looks like (see [Audio API Reference](../reference/audio-api.md)).
+
+## Why Krumhansl-Schmuckler for Key Estimation
+
+The Krumhansl-Schmuckler (K-S) algorithm correlates a chroma vector against psychoacoustically derived key profiles. It was chosen for several reasons:
+
+1. **Simplicity.** K-S is a single dot-product per candidate key — 24 correlations total (12 major + 12 minor). This keeps inference fast enough for real-time segment analysis.
+2. **Well-studied failure modes.** K-S has been benchmarked extensively in MIR literature. Its biases are predictable: it overestimates major keys for ambiguous inputs and struggles with modal music. Knowing the failure modes lets us compensate downstream.
+3. **No training data required.** The key profiles are fixed constants, not learned parameters. This avoids the cold-start problem and makes results deterministic.
+
+The primary limitation is that K-S only distinguishes major (Ionian) from minor (Aeolian). It cannot detect Dorian, Mixolydian, or other modes directly. The pattern engine handles modal detection in a second pass, using the K-S result as a starting hypothesis.
+
+## How Template Matching Works for Chord Estimation
+
+The chord estimation layer slides a window across the 2D chroma matrix `(12, T)` and computes the cosine similarity between each window's chroma and a set of chord templates (major, minor, diminished, augmented triads and dominant 7ths).
+
+### Template construction
+
+Each template is a 12-dimensional binary vector with 1s at the chord tones and 0s elsewhere. For example, a C major template has 1s at pitch classes 0 (C), 4 (E), and 7 (G).
+
+### Tonal bias
+
+Before comparison, the cosine similarity for chords that are diatonic to the estimated global key receives a small additive bonus (default: 0.15). This breaks ties in favor of diatonic interpretations, which is the musically correct default for most tonal music.
+
+### Limitations
+
+- **Only major/minor triads and dom7 for v1.** The template set intentionally omits diminished, augmented, and extended chords. Adding them would increase false positives more than it would improve recall — the chroma resolution of most audio is too coarse to distinguish, say, Cmaj7 from C.
+- **No voice leading.** Templates treat each window independently. A proper chord tracker would use Viterbi decoding or HMM smoothing across windows, which is a natural v2 extension.
+- **Polyphonic music only.** Monophonic lines produce very sparse chroma and the cosine metric degenerates. For monophonic analysis, use the melody pipeline instead.
+
+## When to Trust the Chord Layer
+
+**Trust it when:**
+- The audio is polyphonic (guitar strumming, piano, ensemble)
+- The recording is relatively clean (low reverb, no heavy distortion)
+- Chord confidence values are above 0.6
+
+**Be skeptical when:**
+- Confidence is below 0.4 — the pipeline is guessing
+- `is_diatonic` is `False` for most chords — this may indicate the global key estimate is wrong rather than the music being chromatic
+- The audio is heavily processed (autotune, vocoder, heavy compression)
+
+## Why the Tonal Bias Defaults to 0.15
+
+The tonal bias parameter (`tonal_bias=0.15`) was tuned empirically against a corpus of pop and classical recordings. The tradeoffs:
+
+- **0.0 (no bias):** Pure cosine similarity. Works well for chromatic jazz and atonal music, but produces noisy results for tonal music because diatonic and chromatic chords compete on equal footing.
+- **0.10-0.20:** Sweet spot for most Western tonal music. Diatonic chords win ties without suppressing genuinely chromatic passages.
+- **0.30+:** Over-biased. Starts forcing diatonic interpretations on passages that are genuinely chromatic. Secondary dominants and borrowed chords get misclassified.
+
+The default of 0.15 biases toward diatonic interpretations just enough to smooth out noise without hiding interesting chromatic harmony. You can adjust it per call:
+
+```python
+# Analyzing chromatic jazz — reduce tonal bias
+result = await analyze_audio_async("coltrane.wav", tonal_bias=0.05)
+
+# Analyzing a hymn — increase tonal bias
+result = await analyze_audio_async("hymn.wav", tonal_bias=0.25)
+```
+
+## The Segment Parameter as a Future-Windowing Seam
+
+The `segment=(start, end)` parameter currently selects a single contiguous time window for analysis. This is a deliberate architectural seam for future windowed analysis:
+
+- **v1 (current):** Caller specifies one segment; pipeline analyzes it as a unit.
+- **v2 (planned):** A higher-level orchestrator could slice a file into overlapping windows, call `from_audio(segment=...)` for each, and stitch the results into a time-varying key/chord track. The single-segment API is the primitive that makes this possible without requiring changes to the core pipeline.
+
+The segment bounds appear in the result as `segment_start` and `segment_end`, making it straightforward to align results from multiple calls.
+
+## Diatonic-Only Quality Claim for v1
+
+The v1 audio pipeline makes a deliberate quality/scope tradeoff: it only claims to reliably detect **diatonic** harmony (major and minor triads, dominant 7ths, within a major or minor key).
+
+What this means in practice:
+- Modal music (Dorian, Mixolydian, etc.) gets the correct *key signature* but the mode label will be "Ionian" or "Aeolian" — the K-S algorithm cannot distinguish modes. Pass the result through `PatternAnalysisService` for proper modal detection.
+- Extended chords (maj7, min9, sus4) are simplified to their nearest triad or dom7 template. This is lossy but intentional — chroma resolution in most audio is insufficient for reliable extended chord detection.
+- Chromatic passages (augmented sixths, Neapolitan chords, tritone subs) will be detected as whatever diatonic chord their chroma most resembles. The `is_diatonic=False` flag on individual `ChordEvent` entries signals when the pipeline is less confident about diatonic membership.
+
+This is not a permanent limitation — it is the honest boundary of what template-matching on chroma can deliver without HMM smoothing or neural network chord recognition. Future iterations will extend the quality boundary outward.
+
+## See Also
+
+- [Audio API Reference](../reference/audio-api.md) — field-by-field documentation
+- [How to Analyze Audio](../how-to/audio-analysis.md) — task-oriented guide
+- [Audio Quick Start](../tutorials/audio-quickstart.md) — hands-on tutorial

--- a/docs/how-to/audio-analysis.md
+++ b/docs/how-to/audio-analysis.md
@@ -1,0 +1,157 @@
+# How to Analyze Audio Files
+
+Task-oriented guide for audio analysis with the harmonic-analysis library.
+
+## How to Analyze an Audio File
+
+```python
+from harmonic_analysis import analyze_audio_async
+
+result = await analyze_audio_async("song.wav")
+print(f"Key: {result.global_key.tonic} {result.global_key.mode}")
+print(f"Chords: {result.chords_as_symbols()}")
+```
+
+To analyze only a portion of the file, pass a `segment` tuple of `(start_seconds, end_seconds)`:
+
+```python
+# Analyze just the first 30 seconds
+result = await analyze_audio_async("song.wav", segment=(0.0, 30.0))
+
+# Analyze from 60 seconds to end of file
+result = await analyze_audio_async("song.wav", segment=(60.0, None))
+```
+
+There is also a synchronous wrapper if you are not in an async context:
+
+```python
+from harmonic_analysis import analyze_audio
+
+result = analyze_audio("song.wav")
+```
+
+## How to Chain Audio Analysis into Pattern Analysis
+
+The audio pipeline produces key estimation and chord symbols. Feed those into the pattern engine for full harmonic analysis:
+
+```python
+from harmonic_analysis import analyze_audio_async, PatternAnalysisService
+
+# Step 1: Extract key + chords from audio
+audio_result = await analyze_audio_async("song.wav")
+
+# Step 2: Feed into the pattern engine
+service = PatternAnalysisService()
+pattern_result = await service.analyze_with_patterns_async(
+    chord_symbols=audio_result.chords_as_symbols(),
+    key_hint=audio_result.key_hint,
+    profile="classical",
+)
+
+print(f"Roman numerals: {' - '.join(pattern_result.primary.roman_numerals)}")
+```
+
+## Toolkit Migration Recipe
+
+If you are migrating from a toolkit that expects a `ModeAnalysisResponse`-shaped dict, use this wrapper to bridge the audio pipeline into that shape:
+
+```python
+# toolkit-wrapper-recipe-start
+from harmonic_analysis import analyze_audio_async
+
+
+async def run_wrapper(audio_path):
+    """Bridge audio pipeline output to ModeAnalysisResponse shape."""
+    result = await analyze_audio_async(audio_path)
+
+    result_dict = {
+        "global": {
+            "tonic": result.global_key.tonic,
+            "mode": result.global_key.mode,
+        },
+        "local": {
+            "region_type": result.region.type,
+        },
+        "analysis": {
+            "borrowed_tones": list(result.region.borrowed),
+            "cadence_detected": result.cadences.detected,
+            "chromagram_summary": [0.0] * 12,
+        },
+        "visuals": [],
+    }
+    return result_dict
+# toolkit-wrapper-recipe-end
+```
+
+### Serialization Gap: `visuals`
+
+The toolkit's `ModeAnalysisResponse.visuals` field expects `List[VisualizationItem]` — matplotlib-generated plots. The harmonic-analysis library intentionally has no matplotlib dependency, so the audio pipeline does not produce visualization data.
+
+**Options:**
+
+- **(a)** Compute visuals locally in your wrapper using the original plot functions from the toolkit.
+- **(b) RECOMMENDED:** Make `visuals: Optional[List[VisualizationItem]] = None` in the toolkit's Pydantic model. This keeps the wrapper under 15 lines and matplotlib out of the library.
+
+Option (b) is recommended because `visuals` is a presentation concern, not a data contract. Keeping visualization logic in the toolkit where the plots are rendered avoids coupling the analysis library to a rendering framework.
+
+### Serialization Gap: `chromagram_summary`
+
+The toolkit's `AnalysisDetails.chromagram_summary` field expects `List[float]` — a 12-bin chroma energy vector. The library's audio pipeline uses chroma internally for key estimation but does not currently expose the raw chroma vector in the public result.
+
+**Options:**
+
+- **(a)** Derive the chroma locally from librosa in your wrapper:
+  ```python
+  import librosa
+  y, sr = librosa.load(audio_path)
+  chroma = librosa.feature.chroma_stft(y=y, sr=sr).mean(axis=1).tolist()
+  ```
+- **(b) RECOMMENDED:** Make `chromagram_summary: Optional[List[float]] = None` in the toolkit model.
+
+Option (b) is recommended because the chroma summary is a visualization aid for the frontend, not a load-bearing analysis contract. Making it optional avoids redundant computation and keeps the wrapper simple.
+
+## How to Handle MP3 Files
+
+MP3, AAC, and OGG decoding requires `ffmpeg` on your system PATH. WAV files work without it.
+
+**macOS (Homebrew):**
+```bash
+brew install ffmpeg
+```
+
+**Ubuntu/Debian:**
+```bash
+sudo apt install ffmpeg
+```
+
+**Windows (Chocolatey):**
+```bash
+choco install ffmpeg
+```
+
+The library checks for ffmpeg at construction time and logs a warning if it is missing. You can suppress the warning with `quiet=True`:
+
+```python
+result = await analyze_audio_async("song.mp3", quiet=True)
+```
+
+## How to Interpret Chord Confidence and `is_diatonic`
+
+Each `ChordEvent` in the result includes:
+
+- **`confidence`** — Cosine similarity between the audio chroma and the chord template, after tonal bias adjustment. Values above 0.7 are strong matches; below 0.4 are speculative.
+- **`is_diatonic`** — Whether the detected chord belongs to the estimated global key. Non-diatonic chords may indicate borrowed chords, secondary dominants, or modulation.
+
+```python
+for chord in result.chords:
+    status = "diatonic" if chord.is_diatonic else "chromatic"
+    print(f"{chord.chord_label}: {chord.confidence:.2f} ({status})")
+```
+
+High confidence + non-diatonic is often the most interesting signal — it suggests intentional chromatic harmony rather than noise.
+
+## See Also
+
+- **[Audio Quick Start Tutorial](../tutorials/audio-quickstart.md)** — 5-minute hands-on introduction
+- **[Audio API Reference](../reference/audio-api.md)** — field-by-field documentation
+- **[Audio Analysis Internals](../explanation/audio-analysis-internals.md)** — why the pipeline works the way it does

--- a/docs/reference/audio-api.md
+++ b/docs/reference/audio-api.md
@@ -1,0 +1,159 @@
+# Audio API Reference
+
+Field-by-field reference for the audio analysis surface. For the core pattern analysis API, see [api-reference.md](api-reference.md).
+
+## Module-Level Convenience Functions
+
+### `analyze_audio(path, *, segment=None, quiet=False, include_chords=True, chord_window_size_s=0.5, chord_hop_size_s=0.25, tonal_bias=0.15)`
+
+Synchronous convenience wrapper. Constructs a fresh `AudioAdapter` per call — cheap, the only real work in construction is an ffmpeg-on-PATH check.
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `path` | `str \| Path` | required | Path to an audio file (WAV directly; MP3/AAC/OGG via ffmpeg) |
+| `segment` | `tuple[float, float \| None] \| None` | `None` | Optional `(start_sec, end_sec)` window. `end_sec` may be `None` for "to end of file" |
+| `quiet` | `bool` | `False` | Suppress the ffmpeg-missing WARNING log |
+| `include_chords` | `bool` | `True` | Enable chord estimation layer |
+| `chord_window_size_s` | `float` | `0.5` | Chord estimation analysis window in seconds |
+| `chord_hop_size_s` | `float` | `0.25` | Chord estimation hop size in seconds |
+| `tonal_bias` | `float` | `0.15` | Diatonic similarity bonus for chord template matching |
+
+**Returns:** `AudioAnalysisResult`
+
+**Raises:**
+- `AudioImportError` — if `librosa` or `soundfile` are not installed
+- `ValueError` — for empty or too-short segments
+
+### `analyze_audio_async(path, *, segment=None, quiet=False, include_chords=True, chord_window_size_s=0.5, chord_hop_size_s=0.25, tonal_bias=0.15)`
+
+Async convenience wrapper. Uses `asyncio.to_thread` to keep the blocking librosa work off the event loop. Same parameters and return type as `analyze_audio`.
+
+## `AudioAdapter`
+
+Orchestrator class. Construction is the lazy-import boundary — `librosa` and `soundfile` are imported inside `__init__`.
+
+### Constructor
+
+```python
+AudioAdapter(
+    *,
+    quiet: bool = False,
+    include_chords: bool = True,
+    chord_window_size_s: float = 0.5,
+    chord_hop_size_s: float = 0.25,
+    tonal_bias: float = 0.15,
+)
+```
+
+**Raises:** `AudioImportError` if `librosa` or `soundfile` cannot be imported.
+
+**Attributes:**
+- `ffmpeg_available: bool` — `True` if `ffmpeg` was found on PATH at construction time.
+
+### `from_audio(filepath, *, segment=None) -> AudioAnalysisResult`
+
+Run the full audio analysis pipeline on a file.
+
+**Pipeline steps:**
+1. Extract global chroma (1D `(12,)`) and estimate global key
+2. Resolve segment bounds (default: whole file)
+3. Extract local chroma (2D `(12, T)`) for the segment
+4. Estimate local key from time-averaged local chroma
+5. Detect cadences from raw 2D local chroma
+6. Classify region against the global key
+7. Chord estimation via template matching on local chroma (when `include_chords=True`)
+
+## Result Dataclasses
+
+All result types are frozen dataclasses.
+
+### `AudioAnalysisResult`
+
+The top-level result returned by `analyze_audio` and `AudioAdapter.from_audio`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `global_key` | `KeyInfo` | K-S key estimate over the whole file |
+| `local_key` | `KeyInfo` | K-S key estimate over the analyzed segment |
+| `cadences` | `CadenceInfo` | V-I cadence detection result |
+| `region` | `RegionInfo` | Region classification (stable / modulation / modal_shift) |
+| `chords` | `list[ChordEvent]` | Timestamped chord events (empty if `include_chords=False`) |
+| `segment_start` | `float` | Start of analyzed segment in seconds |
+| `segment_end` | `float` | End of analyzed segment in seconds |
+
+**Properties:**
+
+- `key_hint -> str` — Formats `"<tonic> <mode>"` from the local key, compatible with `PatternAnalysisService.analyze_with_patterns_async(key_hint=...)`. Maps K-S labels (Ionian/Aeolian) to standard names (major/minor). Returns `"C major"` for the zero-energy sentinel.
+
+**Methods:**
+
+- `chords_as_symbols() -> list[str]` — Extracts `chord_label` from each `ChordEvent`. The resulting list is directly compatible with `PatternAnalysisService.analyze_with_patterns_async(chord_symbols=...)`.
+
+### `KeyInfo`
+
+Result of Krumhansl-Schmuckler key estimation.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tonic` | `str` | Estimated tonic note name (e.g. `"C"`, `"F#"`) |
+| `mode` | `str` | Estimated mode (`"Ionian"` or `"Aeolian"`) |
+| `key_signature` | `str` | Formatted key string (e.g. `"C Ionian"`) |
+| `confidence` | `float` | Correlation coefficient from K-S profile matching |
+| `diatonic_pitch_classes` | `frozenset[int]` | Derived field — pitch-class integers for the diatonic scale. **Not JSON-serializable.** Computed from `tonic` + `mode` in `__post_init__` |
+
+> **Warning:** `diatonic_pitch_classes` is a `frozenset`. Passing a `KeyInfo` through `dataclasses.asdict()` and then to a JSON serializer will raise `TypeError`. Always build response dicts manually when serializing `KeyInfo`.
+
+### `CadenceInfo`
+
+Result of cadence detection on a chroma segment.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `detected` | `bool` | Whether a V-I cadence pattern was found |
+| `strength` | `float` | Strength of the detected cadence (0.0-1.0) |
+
+### `RegionInfo`
+
+Region classification comparing local segment against global key.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `str` | One of `"stable"`, `"modulation"`, `"modal_shift"` |
+| `confidence` | `float` | Classification confidence (0.0-1.0) |
+| `borrowed` | `list[str]` | Pitch-class names of tones present locally but absent from the global diatonic set |
+
+### `ChordEvent`
+
+A single timestamped chord detection.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `start_time` | `float` | Start time in seconds |
+| `end_time` | `float` | End time in seconds |
+| `chord_label` | `str` | Detected chord symbol (e.g. `"C"`, `"Am"`, `"G7"`) |
+| `confidence` | `float` | Cosine similarity (post-tonal-bias) averaged over constituent windows |
+| `is_diatonic` | `bool` | Whether the chord root belongs to the global key's diatonic pitch-class set |
+
+## Exceptions
+
+### `AudioImportError`
+
+Subclass of `ImportError`. Raised when `librosa` or `soundfile` are not installed. The message contains the strings `"audio"` and `"pip install"` for grep-friendly install guidance.
+
+```python
+from harmonic_analysis import AudioImportError
+
+try:
+    result = analyze_audio("song.wav")
+except AudioImportError:
+    print("Install with: pip install harmonic-analysis[audio]")
+```
+
+## See Also
+
+- [Core API Reference](api-reference.md) — pattern analysis, scale/melody analysis, musical data API
+- [Audio Quick Start](../tutorials/audio-quickstart.md) — 5-minute hands-on tutorial
+- [How to Analyze Audio](../how-to/audio-analysis.md) — task-oriented guide
+- [Audio Internals](../explanation/audio-analysis-internals.md) — design rationale

--- a/docs/tutorials/audio-quickstart.md
+++ b/docs/tutorials/audio-quickstart.md
@@ -1,0 +1,79 @@
+# Audio Analysis Quick Start
+
+A 5-minute hands-on walkthrough: install the audio extra, point it at a WAV file, and see what comes back.
+
+## Prerequisites
+
+- Python 3.10+
+- A working `harmonic-analysis` installation (see [Getting Started](getting-started.md))
+
+## Step 1 — Install the Audio Extra
+
+```bash
+pip install harmonic-analysis[audio]
+```
+
+This pulls in `librosa` (signal processing) and `soundfile` (audio I/O). If you plan to analyze MP3 or AAC files, you also need `ffmpeg` on your PATH — WAV works without it.
+
+## Step 2 — Get or Create a Sample File
+
+Any WAV file will do. If you don't have one handy, generate a quick test tone:
+
+```python
+import numpy as np
+import soundfile as sf
+
+sr = 22050
+t = np.linspace(0, 3.0, int(sr * 3.0), endpoint=False)
+# A major chord: A4 + C#5 + E5
+signal = (
+    0.4 * np.sin(2 * np.pi * 440 * t)
+    + 0.3 * np.sin(2 * np.pi * 554.37 * t)
+    + 0.3 * np.sin(2 * np.pi * 659.25 * t)
+)
+sf.write("sample.wav", signal, sr)
+```
+
+## Step 3 — Run the Analysis
+
+```python
+import asyncio
+from harmonic_analysis import analyze_audio_async
+
+async def main():
+    result = await analyze_audio_async("sample.wav")
+
+    print(f"Global key: {result.global_key.tonic} {result.global_key.mode}")
+    print(f"  Confidence: {result.global_key.confidence:.2f}")
+    print(f"Cadence detected: {result.cadences.detected}")
+    print(f"Region type: {result.region.type}")
+    print(f"Chords found: {len(result.chords)}")
+
+    for chord in result.chords[:5]:
+        print(
+            f"  [{chord.start_time:.2f}-{chord.end_time:.2f}] "
+            f"{chord.chord_label} (conf={chord.confidence:.2f}, "
+            f"diatonic={chord.is_diatonic})"
+        )
+
+asyncio.run(main())
+```
+
+## Step 4 — Understand the Output
+
+| Field | What it tells you |
+|-------|-------------------|
+| `global_key` | Krumhansl-Schmuckler key estimate over the whole file |
+| `local_key` | Key estimate for the analyzed segment (same as global when no segment is given) |
+| `cadences` | Whether a V-I cadence was detected and how strong it is |
+| `region` | Whether the segment is stable, a modulation, or a modal shift |
+| `chords` | Timestamped chord events with template-matching confidence |
+| `segment_start` / `segment_end` | The time window that was analyzed (seconds) |
+
+The `key_hint` property on the result formats a service-ready string like `"A major"` that you can pass directly to `PatternAnalysisService.analyze_with_patterns_async(key_hint=...)` for follow-up pattern analysis.
+
+## What's Next
+
+- **[How to analyze audio files](../how-to/audio-analysis.md)** — task-oriented guide with segment windowing, MP3 setup, and toolkit integration recipes
+- **[Audio API Reference](../reference/audio-api.md)** — field-by-field documentation for every dataclass and function
+- **[Audio Analysis Internals](../explanation/audio-analysis-internals.md)** — why the pipeline makes the choices it does

--- a/scripts/compare_audio_to_midi.py
+++ b/scripts/compare_audio_to_midi.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""Compare audio chord estimation against a MIDI ground truth.
+
+For each ChordEvent the audio analyzer produces (or for a fixed time grid),
+read the simultaneous MIDI notes, infer their chord identity from the
+pitch-class set, and report agreement vs disagreement.
+
+Usage:
+    python scripts/compare_audio_to_midi.py audio.mp3 ground.mid
+    python scripts/compare_audio_to_midi.py audio.mp3 ground.mid --bass-chroma
+    python scripts/compare_audio_to_midi.py audio.mp3 ground.mid --grid 0.25
+
+The "chord identity from MIDI" inference is intentionally simple:
+    1. Take pitch classes of all notes sounding in the window.
+    2. Try every (root × {major, minor}) template; pick the best fit.
+    3. Bias toward the template that includes the lowest-MIDI note as root.
+That's not a full chord-recognition system — it's just "what triad best
+fits the notes that are sounding right now," which is what we want to
+compare against the audio's template-matching estimator.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+
+# Pitch class names — keep in sync with PITCH_CLASSES in audio/_profiles.py
+PCS = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+
+# Triad templates: root index → set of pitch class indices
+MAJ = {0, 4, 7}
+MIN = {0, 3, 7}
+
+# DTW frame rate — coarser than audio's chroma analysis but plenty for
+# alignment. 50ms hops at 22050 Hz with hop_length=1102 ≈ 20 fps. Tuning
+# coarser than this risks missing fast chord changes; finer than this
+# inflates the DTW matrix to no useful end. Magic number lifted from
+# typical MIR alignment papers.
+DTW_HOP_SEC = 0.05
+
+
+def _midi_pitch_class(midi: int) -> int:
+    """MIDI note number → pitch class 0-11."""
+    return midi % 12
+
+
+def _label_for_root(root_pc: int, quality: str) -> str:
+    """Build a chord label like 'D' or 'Bm'."""
+    return PCS[root_pc] + ("m" if quality == "minor" else "")
+
+
+def _midi_chord_at(
+    midi_notes: List[Tuple[float, float, int]],
+    t_start: float,
+    t_end: float,
+) -> Optional[str]:
+    """Best-fit major/minor triad over notes sounding in [t_start, t_end].
+
+    Args:
+        midi_notes: List of (start_sec, end_sec, midi_pitch).
+        t_start: Window start in seconds.
+        t_end: Window end in seconds.
+
+    Returns:
+        Chord label (e.g. 'Bm', 'D') or None if no notes are sounding.
+    """
+    # Notes that overlap the window
+    sounding = [(s, e, p) for s, e, p in midi_notes if s < t_end and e > t_start]
+    if not sounding:
+        return None
+
+    # Pitch class set, weighted by how much each note overlaps the window.
+    # A held note covering the whole window counts more than a brief one.
+    pc_weight = [0.0] * 12
+    for s, e, p in sounding:
+        overlap = max(0.0, min(e, t_end) - max(s, t_start))
+        pc_weight[_midi_pitch_class(p)] += overlap
+
+    # Lowest sounding note → bias toward triads where it's the root
+    lowest_pc = _midi_pitch_class(min(p for _, _, p in sounding))
+
+    # Score every (root, quality) triad by weighted PC match
+    best_score = -1.0
+    best_label = None
+    for root in range(12):
+        for quality, intervals in (("major", MAJ), ("minor", MIN)):
+            triad_pcs = {(root + i) % 12 for i in intervals}
+            score = sum(pc_weight[pc] for pc in triad_pcs)
+            # Bonus when the bass note is the root (the inversion-aware nudge)
+            if root == lowest_pc:
+                score += 0.3 * sum(pc_weight)
+            if score > best_score:
+                best_score = score
+                best_label = _label_for_root(root, quality)
+    return best_label
+
+
+def _midi_total_duration(midi_notes: List[Tuple[float, float, int]]) -> float:
+    """End-time of the last sounding note. Zero if the file is empty."""
+    return max((end for _, end, _ in midi_notes), default=0.0)
+
+
+def _load_midi(midi_path: Path) -> List[Tuple[float, float, int]]:
+    """Parse a MIDI file → list of (start_sec, end_sec, midi_pitch).
+
+    Uses music21 (already a project dep). Tempo is taken from the first
+    MetronomeMark; if absent, defaults to 120. Tempo changes inside the
+    file aren't honored — fine for short pieces, lossy for long ones.
+    """
+    from music21 import chord as m21chord
+    from music21 import converter
+    from music21 import note as m21note
+
+    s = converter.parse(str(midi_path))
+    flat = s.flatten().notes
+
+    # Tempo for beat→seconds conversion. music21 stores offsets in
+    # quarter-note beats; multiply by (60 / bpm) for seconds.
+    mm = s.flatten().getElementsByClass("MetronomeMark")
+    bpm = float(mm[0].number) if mm else 120.0
+    sec_per_beat = 60.0 / bpm
+
+    out: List[Tuple[float, float, int]] = []
+    for elem in flat:
+        start_sec = float(elem.offset) * sec_per_beat
+        dur_sec = float(elem.duration.quarterLength) * sec_per_beat
+        end_sec = start_sec + dur_sec
+        if isinstance(elem, m21note.Note):
+            out.append((start_sec, end_sec, elem.pitch.midi))
+        elif isinstance(elem, m21chord.Chord):
+            for p in elem.pitches:
+                out.append((start_sec, end_sec, p.midi))
+    return out
+
+
+def _format_label(label: Optional[str]) -> str:
+    return label if label else "—"
+
+
+def _synthesize_midi_chroma(
+    midi_notes: List[Tuple[float, float, int]],
+    total_duration: float,
+    hop_sec: float = DTW_HOP_SEC,
+) -> "np.ndarray":  # type: ignore[name-defined]  # noqa: F821
+    """Build a per-frame chroma matrix from MIDI note events.
+
+    For each frame, sum a 1.0 contribution per sounding note's pitch class,
+    plus a 0.5 contribution at the octave (same PC) to model the first
+    harmonic. That's not a full physical model, but it's enough to give
+    DTW the smooth chroma shape it needs for cosine-distance alignment.
+
+    Args:
+        midi_notes: List of (start_sec, end_sec, midi_pitch) tuples.
+        total_duration: Length of the MIDI in seconds.
+        hop_sec: Frame hop size.
+
+    Returns:
+        ``np.ndarray`` shape ``(12, n_frames)``, L2-normalized per column.
+    """
+    import numpy as np
+
+    n_frames = int(total_duration / hop_sec) + 2
+    chroma = np.zeros((12, n_frames), dtype=np.float64)
+
+    for start_s, end_s, pitch in midi_notes:
+        f0 = max(0, int(start_s / hop_sec))
+        f1 = min(n_frames, int(end_s / hop_sec) + 1)
+        if f1 <= f0:
+            continue
+        pc = pitch % 12
+        # Fundamental contribution
+        chroma[pc, f0:f1] += 1.0
+        # First harmonic at the octave — same PC, slightly weaker.
+        # Mostly a fail-safe; if a note is held the chroma value already
+        # accumulates, so this is mainly relevant for staccato playing.
+        chroma[pc, f0:f1] += 0.5
+
+    # L2-normalize each column. Silent frames (norm=0) stay zero — DTW's
+    # cosine metric handles that fine (cosine of zero vector is undefined,
+    # but librosa's cosine-distance treats it as max distance).
+    # Replace zero norms with 1 BEFORE dividing — np.where doesn't
+    # short-circuit, and ``chroma / norms`` still produces NaN for any
+    # column with norm 0 even if the where-clause discards it.
+    norms = np.linalg.norm(chroma, axis=0, keepdims=True)
+    safe_norms = np.where(norms > 0, norms, 1.0)
+    chroma = chroma / safe_norms
+    return chroma
+
+
+def _compute_audio_chroma(
+    audio_path: Path, hop_sec: float = DTW_HOP_SEC
+) -> "np.ndarray":  # type: ignore[name-defined]  # noqa: F821
+    """Extract chroma_cqt from an audio file at the given frame rate.
+
+    librosa's hop_length is in samples, so we convert: hop_length =
+    int(hop_sec * sr). Slightly fudged for sr=22050 (≈ 1102 samples per
+    50ms frame) — librosa's CQT internally rounds to power-of-two-ish
+    boundaries but the hop is honored.
+    """
+    import librosa
+    import numpy as np
+
+    y, sr = librosa.load(str(audio_path), sr=22050, mono=True)
+    hop_length = int(round(hop_sec * sr))
+    chroma: "np.ndarray" = librosa.feature.chroma_cqt(y=y, sr=sr, hop_length=hop_length)
+    # L2-normalize for cosine-distance DTW
+    # Replace zero norms with 1 BEFORE dividing — np.where doesn't
+    # short-circuit, and ``chroma / norms`` still produces NaN for any
+    # column with norm 0 even if the where-clause discards it.
+    norms = np.linalg.norm(chroma, axis=0, keepdims=True)
+    safe_norms = np.where(norms > 0, norms, 1.0)
+    chroma = chroma / safe_norms
+    return chroma
+
+
+def _build_dtw_warp(
+    audio_path: Path,
+    midi_notes: List[Tuple[float, float, int]],
+    midi_total_duration: float,
+    hop_sec: float = DTW_HOP_SEC,
+) -> Callable[[float], float]:
+    """DTW-align audio chroma to MIDI chroma; return a warping function.
+
+    The returned function maps audio time (seconds) → MIDI time (seconds).
+    librosa's DTW with ``subseq=True`` lets the audio sequence start
+    anywhere in the MIDI sequence, which is exactly what we want when the
+    audio has lead-in silence.
+
+    Implementation note: the warping path comes back as a (P, 2) array of
+    (audio_frame, midi_frame) pairs in reverse order. We flip it, convert
+    frames to seconds, and use ``np.interp`` for piecewise-linear
+    interpolation between path nodes.
+    """
+    import librosa
+    import numpy as np
+
+    audio_chroma = _compute_audio_chroma(audio_path, hop_sec=hop_sec)
+    midi_chroma = _synthesize_midi_chroma(
+        midi_notes, total_duration=midi_total_duration, hop_sec=hop_sec
+    )
+    print(
+        f"  DTW: audio {audio_chroma.shape[1]} frames, "
+        f"MIDI {midi_chroma.shape[1]} frames, hop={hop_sec}s"
+    )
+
+    # Cost matrix + warping path. subseq=True means the start of the
+    # MIDI sequence can match anywhere along the audio sequence — this
+    # is what lets us handle lead-in silence cleanly without having to
+    # pre-compute a constant offset.
+    #
+    # Metric note: cosine distance on L2-normalized chroma is the natural
+    # similarity metric, but cosine is undefined on zero vectors (silent
+    # frames) and produces NaNs in the cost matrix that DTW then refuses.
+    # Euclidean distance on the same L2-normalized features gives a
+    # monotonically equivalent ordering — the DTW path is the same up to
+    # rounding — and well-defined everywhere. Lessons hard-won from a
+    # NaN cost matrix.
+    _, wp = librosa.sequence.dtw(
+        X=midi_chroma, Y=audio_chroma, subseq=True, metric="euclidean"
+    )
+
+    # wp shape (P, 2): each row is (midi_frame, audio_frame). Reverse so
+    # rows are in increasing time order.
+    wp = wp[::-1]
+    midi_frames = wp[:, 0].astype(np.float64)
+    audio_frames = wp[:, 1].astype(np.float64)
+    audio_times = audio_frames * hop_sec
+    midi_times = midi_frames * hop_sec
+
+    # Sort by audio time (DTW path is monotonic but may have plateau
+    # ties; the sort is just defensive).
+    order = np.argsort(audio_times)
+    audio_times = audio_times[order]
+    midi_times = midi_times[order]
+
+    # Drop duplicates so np.interp's xp is strictly increasing
+    unique_mask = np.concatenate(([True], np.diff(audio_times) > 0))
+    audio_times = audio_times[unique_mask]
+    midi_times = midi_times[unique_mask]
+
+    def warp(audio_t: float) -> float:
+        # np.interp clamps at the endpoints, which is the right behavior
+        # for audio outside the DTW window (lead-in / trail-out silence).
+        return float(np.interp(audio_t, audio_times, midi_times))
+
+    return warp
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("audio", type=Path, help="Audio file (WAV/MP3)")
+    parser.add_argument("midi", type=Path, help="MIDI ground truth")
+    parser.add_argument(
+        "--bass-chroma",
+        action="store_true",
+        dest="bass_chroma",
+        help="enable bass-aware chord estimation in the audio analyzer",
+    )
+    parser.add_argument(
+        "--bass-bonus",
+        type=float,
+        default=0.3,
+        dest="bass_bonus",
+    )
+    parser.add_argument(
+        "--tonal-bias",
+        type=float,
+        default=0.15,
+        dest="tonal_bias",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=30,
+        help="show first N comparisons (default 30)",
+    )
+    parser.add_argument(
+        "--offset",
+        type=float,
+        default=None,
+        help="audio→MIDI time offset in seconds (auto-detected if omitted). "
+        "audio time T corresponds to MIDI time T - offset.",
+    )
+    parser.add_argument(
+        "--energy-threshold",
+        type=float,
+        default=0.01,
+        dest="energy_threshold",
+        help="amplitude threshold for auto-detecting audio start (default 0.01)",
+    )
+    parser.add_argument(
+        "--dtw",
+        action="store_true",
+        help="use Dynamic Time Warping to align audio→MIDI time. "
+        "Handles tempo drift / rubato that constant offset can't.",
+    )
+    args = parser.parse_args()
+
+    if not args.audio.exists():
+        print(f"error: no such file: {args.audio}", file=sys.stderr)
+        return 2
+    if not args.midi.exists():
+        print(f"error: no such file: {args.midi}", file=sys.stderr)
+        return 2
+
+    print(f"loading MIDI: {args.midi}")
+    midi_notes = _load_midi(args.midi)
+    print(f"  {len(midi_notes)} note events")
+
+    # Build the audio→MIDI time mapping. Three modes, in order of
+    # robustness: --dtw (handles rubato + lead-in), --offset (constant
+    # offset), or auto-detect from first audible sample (constant offset
+    # too, but inferred from the audio).
+    warp: Callable[[float], float]
+    if args.dtw:
+        midi_dur = _midi_total_duration(midi_notes)
+        print(f"DTW alignment (MIDI duration: {midi_dur:.2f}s)")
+        warp = _build_dtw_warp(args.audio, midi_notes, midi_dur)
+        print(
+            f"  warp samples: 0.0s→{warp(0.0):.2f}s, "
+            f"5.0s→{warp(5.0):.2f}s, "
+            f"100.0s→{warp(100.0):.2f}s"
+        )
+    elif args.offset is not None:
+        offset_const = float(args.offset)
+        print(f"using explicit offset: {offset_const:.3f}s (constant)")
+        warp = lambda t: t - offset_const  # noqa: E731
+    else:
+        import numpy as np
+        import soundfile as sf
+
+        y, sr = sf.read(str(args.audio))
+        y_mono = y if y.ndim == 1 else y.mean(axis=1)
+        energy = np.abs(y_mono)
+        first_idx = int(np.argmax(energy > args.energy_threshold))
+        offset_const = first_idx / float(sr)
+        print(
+            f"auto-detected offset: {offset_const:.3f}s "
+            f"(first sample > {args.energy_threshold} amplitude, constant)"
+        )
+        warp = lambda t: t - offset_const  # noqa: E731
+
+    print(f"analyzing audio: {args.audio}  (bass_chroma={args.bass_chroma})")
+    from harmonic_analysis import analyze_audio_async
+
+    result = await analyze_audio_async(
+        args.audio,
+        use_bass_chroma=args.bass_chroma,
+        bass_bonus=args.bass_bonus,
+        tonal_bias=args.tonal_bias,
+    )
+    audio_chords = result.chords
+    print(f"  global key: {result.global_key.tonic} {result.global_key.mode}")
+    print(f"  {len(audio_chords)} chord events")
+    print()
+
+    # Compare every audio chord event against the MIDI ground truth at the
+    # same time window. "Match" allows enharmonic equivalents (D# == Eb)
+    # because we labeled both sides with sharps.
+    print(
+        f"{'audio time':>14}  {'midi time':>14}  "
+        f"{'audio':>8}  {'midi':>8}  {'match'}"
+    )
+    print("-" * 64)
+    matches = 0
+    total = 0
+    shown = 0
+    mismatches: List[Tuple[float, float, str, str]] = []
+    for ce in audio_chords:
+        # Audio time T maps to MIDI time warp(T). DTW or constant offset.
+        midi_t_start = warp(ce.start_time)
+        midi_t_end = warp(ce.end_time)
+        # Skip events that fall before the MIDI starts (e.g., events
+        # entirely in the audio's lead-in silence).
+        if midi_t_end <= 0:
+            continue
+        midi_label = _midi_chord_at(midi_notes, midi_t_start, midi_t_end)
+        is_match = midi_label is not None and midi_label == ce.chord_label
+        if midi_label is not None:
+            total += 1
+            if is_match:
+                matches += 1
+            else:
+                mismatches.append(
+                    (ce.start_time, ce.end_time, ce.chord_label, midi_label)
+                )
+        if shown < args.limit:
+            mark = "ok" if is_match else ("? " if midi_label is None else "no")
+            print(
+                f"  {ce.start_time:6.2f}-{ce.end_time:6.2f}  "
+                f"{midi_t_start:6.2f}-{midi_t_end:6.2f}  "
+                f"{ce.chord_label:>8}  {_format_label(midi_label):>8}  {mark}"
+            )
+            shown += 1
+
+    print()
+    print(
+        f"matches: {matches}/{total} = {100.0 * matches / total:.1f}%"
+        if total
+        else "no overlapping events"
+    )
+
+    # Top mismatches grouped by (audio_label, midi_label) pair
+    if mismatches:
+        print()
+        print("mismatch frequency (audio → midi):")
+        from collections import Counter
+
+        pair_counts = Counter((a, m) for _, _, a, m in mismatches)
+        for (audio_lbl, midi_lbl), count in pair_counts.most_common(10):
+            print(f"  {audio_lbl:>6} → {midi_lbl:<6}  ({count}×)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/try_audio.py
+++ b/scripts/try_audio.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Poke the audio adapter from the command line.
+
+Direct library call — no server, no curl. Skips the HTTP layer entirely
+so you're testing what `analyze_audio_async` actually returns, not what
+the FastAPI serializer made of it.
+
+Usage:
+    python scripts/try_audio.py path/to/your.wav
+    python scripts/try_audio.py path/to/your.wav --start 0 --end 30
+    python scripts/try_audio.py --synth  # generate + analyze /tmp/a_major.wav
+    python scripts/try_audio.py path/to/your.wav --json # raw JSON-ish dump
+
+Requires: pip install -e ".[audio]"  (librosa + soundfile)
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+def _make_synth_wav(path: Path, duration: float = 5.0, sr: int = 22050) -> Path:
+    """A-major triad: tonic + major third + perfect fifth.
+
+    Three partials, equal weights. Pure 440 Hz alone tilts K-S toward A
+    minor about as easily as A major; the C#5 + E5 stack is what makes
+    the 'expect tonic == A' assertion robust.
+    """
+    import numpy as np
+    import soundfile as sf
+
+    t = np.linspace(0, duration, int(sr * duration), endpoint=False)
+    a4 = np.sin(2 * np.pi * 440.00 * t)
+    cs5 = np.sin(2 * np.pi * 554.37 * t)
+    e5 = np.sin(2 * np.pi * 659.25 * t)
+    sig = ((a4 + cs5 + e5) / 3.0 * 0.5).astype("float32")
+    sf.write(str(path), sig, sr)
+    return path
+
+
+def _print_human(result) -> None:
+    """Render the result as a human-friendly summary, not a JSON dump."""
+    g = result.global_key
+    loc = result.local_key
+    reg = result.region
+    cad = result.cadences
+
+    print(f"global key   : {g.tonic} {g.mode}  (conf {g.confidence:.2f})")
+    print(f"local key    : {loc.tonic} {loc.mode}  (conf {loc.confidence:.2f})")
+    print(f"region       : {reg.type}  (conf {reg.confidence:.2f})")
+    if reg.borrowed:
+        print(f"borrowed     : {', '.join(reg.borrowed)}")
+    print(f"cadence      : detected={cad.detected}  strength={cad.strength:.2f}")
+    print(f"segment      : {result.segment_start:.2f}s – {result.segment_end:.2f}s")
+
+    if result.chords:
+        print(f"chords       : {len(result.chords)} events")
+        # First 10 only — long files can get spammy. If you want the rest
+        # use --json and pipe to jq.
+        for c in result.chords[:10]:
+            flag = "yes" if c.is_diatonic else "no "
+            print(
+                f"  {c.start_time:6.2f}-{c.end_time:6.2f}s  "
+                f"{c.chord_label:8}  conf {c.confidence:.2f}  diatonic {flag}"
+            )
+        if len(result.chords) > 10:
+            print(f"  ... and {len(result.chords) - 10} more")
+    else:
+        print("chords       : none detected")
+
+
+def _to_json(result) -> dict:
+    """Manual dict construction. asdict() chokes on KeyInfo's frozenset
+    field — same trap the route dodges. Don't reach for asdict here."""
+    return {
+        "global": {
+            "tonic": result.global_key.tonic,
+            "mode": result.global_key.mode,
+            "key_signature": result.global_key.key_signature,
+            "confidence": result.global_key.confidence,
+        },
+        "local": {
+            "tonic": result.local_key.tonic,
+            "mode": result.local_key.mode,
+            "key_signature": result.local_key.key_signature,
+            "confidence": result.local_key.confidence,
+        },
+        "region": {
+            "type": result.region.type,
+            "confidence": result.region.confidence,
+            "borrowed": list(result.region.borrowed),
+        },
+        "cadence": {
+            "detected": result.cadences.detected,
+            "strength": result.cadences.strength,
+        },
+        "segment": {
+            "start": result.segment_start,
+            "end": result.segment_end,
+        },
+        "chords": [
+            {
+                "start_time": c.start_time,
+                "end_time": c.end_time,
+                "chord_label": c.chord_label,
+                "confidence": c.confidence,
+                "is_diatonic": c.is_diatonic,
+            }
+            for c in result.chords
+        ],
+    }
+
+
+async def _run(
+    filepath: Path,
+    start: Optional[float],
+    end: Optional[float],
+    as_json: bool,
+    tonal_bias: float,
+    window: float,
+    hop: float,
+    bass_chroma: bool,
+    bass_bonus: float,
+) -> int:
+    try:
+        from harmonic_analysis import analyze_audio_async
+    except ImportError as exc:
+        print(
+            f"error: harmonic_analysis import failed: {exc}\n"
+            f'hint:  pip install -e ".[audio]"  from project root',
+            file=sys.stderr,
+        )
+        return 2
+
+    segment = (start, end) if start is not None else None
+    result = await analyze_audio_async(
+        filepath,
+        segment=segment,
+        tonal_bias=tonal_bias,
+        chord_window_size_s=window,
+        chord_hop_size_s=hop,
+        use_bass_chroma=bass_chroma,
+        bass_bonus=bass_bonus,
+    )
+
+    if as_json:
+        print(json.dumps(_to_json(result), indent=2))
+    else:
+        _print_human(result)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the audio adapter against a file.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "filepath",
+        nargs="?",
+        type=Path,
+        help="path to a WAV/FLAC/MP3 file (MP3 needs ffmpeg on PATH)",
+    )
+    parser.add_argument(
+        "--start", type=float, default=None, help="segment start (seconds)"
+    )
+    parser.add_argument("--end", type=float, default=None, help="segment end (seconds)")
+    parser.add_argument(
+        "--synth",
+        action="store_true",
+        help="generate /tmp/a_major.wav and analyze it (no input file needed)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit JSON instead of the human-friendly summary",
+    )
+    # Chord-layer knobs. Defaults match the library defaults; expose them
+    # so you can A/B without editing this file. Common diagnostic moves:
+    #   --tonal-bias 0       turn off the tonic-preference nudge entirely
+    #   --tonal-bias 0.05    softer bias for songs that pivot to vi often
+    #   --window 0.25        smaller window catches faster chord changes
+    parser.add_argument(
+        "--tonal-bias",
+        type=float,
+        default=0.15,
+        dest="tonal_bias",
+        help="tonic preference weight (default 0.15, set 0 to disable)",
+    )
+    parser.add_argument(
+        "--window",
+        type=float,
+        default=0.5,
+        help="chord window size in seconds (default 0.5)",
+    )
+    parser.add_argument(
+        "--hop",
+        type=float,
+        default=0.25,
+        help="chord hop size in seconds (default 0.25)",
+    )
+    # Bass-aware chord estimation. Off by default — opt in to A/B against
+    # the existing full-spectrum-only behavior. Disambiguates relative
+    # pairs (Bm vs D, Am vs C) when the bass note is the discriminator.
+    parser.add_argument(
+        "--bass-chroma",
+        action="store_true",
+        dest="bass_chroma",
+        help="enable bass-aware chord estimation (extra chroma pass over bass register)",  # noqa: E501
+    )
+    parser.add_argument(
+        "--bass-bonus",
+        type=float,
+        default=0.3,
+        dest="bass_bonus",
+        help="bass-root-match bonus when --bass-chroma is on (default 0.3)",
+    )
+    args = parser.parse_args()
+
+    if args.synth:
+        target = Path("/tmp/a_major.wav")
+        try:
+            _make_synth_wav(target)
+        except ImportError as exc:
+            print(
+                f"error: numpy/soundfile not available: {exc}\n"
+                f'hint:  pip install -e ".[audio]"',
+                file=sys.stderr,
+            )
+            return 2
+        if not args.json:
+            print(f"(generated synthetic A-major WAV at {target})")
+        args.filepath = target
+
+    if args.filepath is None:
+        parser.print_usage(sys.stderr)
+        print("error: provide a filepath or use --synth", file=sys.stderr)
+        return 2
+
+    if not args.filepath.exists():
+        print(f"error: no such file: {args.filepath}", file=sys.stderr)
+        return 2
+
+    return asyncio.run(
+        _run(
+            args.filepath,
+            args.start,
+            args.end,
+            args.json,
+            args.tonal_bias,
+            args.window,
+            args.hop,
+            args.bass_chroma,
+            args.bass_bonus,
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/try_audio_http.sh
+++ b/scripts/try_audio_http.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Poke the /api/analyze/audio route with curl.
+#
+# Direct library calls live in scripts/try_audio.py — use that if you
+# don't need the HTTP round-trip. This script is for proving the route
+# works end-to-end (FastAPI multipart, JSON serialization, the whole
+# stack) without firing up a browser.
+#
+# Usage:
+#   ./scripts/try_audio_http.sh path/to/your.wav
+#   ./scripts/try_audio_http.sh path/to/your.wav 0 30        # segment 0-30s
+#   ./scripts/try_audio_http.sh --synth                       # generate + post /tmp/a_major.wav
+#   PORT=8765 ./scripts/try_audio_http.sh path/to/your.wav    # override port
+#
+# Requires: backend running on $PORT (default 8000). Start it with:
+#   uvicorn demo.backend.rest_api.main:app --reload --port 8000
+# from the project root.
+
+set -euo pipefail
+
+PORT="${PORT:-8000}"
+HOST="${HOST:-127.0.0.1}"
+URL="http://${HOST}:${PORT}/api/analyze/audio"
+
+# bash 3.2 — no associative arrays, no ${var^^}. macOS default ships 3.2.
+synth_wav() {
+  # Three-partial A-major triad. Same recipe as scripts/try_audio.py
+  # so the smoke-test signal is consistent across tools.
+  python3 - <<'PY'
+import numpy as np, soundfile as sf
+t = np.linspace(0, 5, 22050 * 5, endpoint=False)
+sig = (np.sin(2*np.pi*440*t) + np.sin(2*np.pi*554.37*t) + np.sin(2*np.pi*659.25*t)) / 3
+sf.write('/tmp/a_major.wav', (sig * 0.5).astype('float32'), 22050)
+PY
+  echo "/tmp/a_major.wav"
+}
+
+if [[ "${1:-}" == "--synth" ]]; then
+  echo "(generating synthetic A-major WAV...)" >&2
+  FILE="$(synth_wav)"
+  START="${2:-}"
+  END="${3:-}"
+else
+  FILE="${1:-}"
+  START="${2:-}"
+  END="${3:-}"
+fi
+
+if [[ -z "${FILE}" ]]; then
+  echo "usage: $0 <wav-file> [start-sec] [end-sec]" >&2
+  echo "       $0 --synth [start-sec] [end-sec]" >&2
+  exit 2
+fi
+
+if [[ ! -f "${FILE}" ]]; then
+  echo "error: no such file: ${FILE}" >&2
+  exit 2
+fi
+
+# Quick liveness check so we fail loud if the server isn't up, instead
+# of curl emitting an inscrutable connection-refused.
+if ! curl -fsS "${URL%/api/analyze/audio}/openapi.json" -o /dev/null 2>/dev/null; then
+  echo "error: backend not reachable at ${URL}" >&2
+  echo "hint:  uvicorn demo.backend.rest_api.main:app --port ${PORT}  (from project root)" >&2
+  exit 3
+fi
+
+# Build the form. -F repeats are the same as multiple form fields.
+ARGS=(-sS -X POST -F "file=@${FILE}")
+if [[ -n "${START}" ]]; then
+  ARGS+=(-F "start=${START}")
+fi
+if [[ -n "${END}" ]]; then
+  ARGS+=(-F "end=${END}")
+fi
+
+# Pretty-print if jq is around, otherwise fall back to python's json.tool.
+if command -v jq >/dev/null 2>&1; then
+  curl "${ARGS[@]}" "${URL}" | jq .
+else
+  curl "${ARGS[@]}" "${URL}" | python3 -m json.tool
+fi

--- a/src/harmonic_analysis/audio/_chord_estimation.py
+++ b/src/harmonic_analysis/audio/_chord_estimation.py
@@ -22,12 +22,20 @@ produce plausible-but-noisy results. That's a feature request, not a bug.
 
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import numpy as np
 
 from ._profiles import PITCH_CLASSES
 from ._types import KeyInfo
+
+# Bass-confidence threshold for applying the root-match bonus. Below this,
+# the bass chroma is too flat (no distinct bass note — silent passage,
+# distortion, or instrument with no bass register) and the bonus would
+# push noise around. 0.25 is conservative; 0.4+ would only fire on very
+# clean bass signals. Tunable per-call via the bass_confidence_threshold
+# argument.
+_DEFAULT_BASS_CONF_THRESHOLD = 0.25
 
 
 def _build_chord_templates() -> Dict[str, np.ndarray]:
@@ -103,23 +111,48 @@ def estimate_chord_progression(
     window_size_s: float = 0.5,
     hop_size_s: float = 0.25,
     tonal_bias: float = 0.15,
+    bass_chroma_frames: Optional[np.ndarray] = None,
+    bass_bonus: float = 0.3,
+    bass_confidence_threshold: float = _DEFAULT_BASS_CONF_THRESHOLD,
 ) -> list:
     """Estimate a chord progression from a 2D chroma matrix.
 
     Slides a window over the chroma frames, computes cosine similarity
     against 48 major/minor triad templates, applies optional tonal bias
-    for diatonic chords, smooths with a running median, and consolidates
-    consecutive identical labels into ChordEvent instances.
+    for diatonic chords, optionally applies a bass-aware root-match
+    bonus, smooths with a running median, and consolidates consecutive
+    identical labels into ChordEvent instances.
 
     Args:
-        local_chroma_frames: Shape ``(12, T)`` chroma matrix from librosa.
-        global_key: KeyInfo with ``diatonic_pitch_classes`` and ``confidence``.
+        local_chroma_frames: Shape ``(12, T)`` full-spectrum chroma matrix
+            from librosa.
+        global_key: KeyInfo with ``diatonic_pitch_classes`` and
+            ``confidence``.
         sr: Sample rate used during chroma extraction.
-        hop_length: Hop length used during chroma extraction (librosa default: 512).
+        hop_length: Hop length used during chroma extraction (librosa
+            default: 512).
         window_size_s: Analysis window size in seconds.
         hop_size_s: Analysis hop size in seconds.
-        tonal_bias: Bonus added to cosine similarity for diatonic chord templates.
-            Set to 0.0 to disable. Auto-zeroed when ``global_key.confidence < 0.5``.
+        tonal_bias: Bonus added to cosine similarity for diatonic chord
+            templates. Set to 0.0 to disable. Auto-zeroed when
+            ``global_key.confidence < 0.5``.
+        bass_chroma_frames: Optional shape ``(12, T)`` bass-register
+            chroma (e.g., from ``extract_local_bass_chroma``). When
+            provided, each window's dominant bass pitch class adds a
+            per-template bonus to chord templates whose root matches —
+            the disambiguator for relative-pair confusions like Bm vs D
+            and Am vs C. Must have the same time axis as
+            ``local_chroma_frames``; mismatched shapes are silently
+            skipped (best-effort fallback to full-spectrum behavior).
+        bass_bonus: Maximum bonus added to a template's cosine similarity
+            when its root matches the detected bass pitch class. Scaled
+            by per-window bass confidence — silent or flat-bass windows
+            contribute zero. 0.3 is roughly equal to two diatonic biases;
+            0.5 is aggressive; 0.15 is gentle.
+        bass_confidence_threshold: Minimum bass-chroma peakiness (max-PC
+            value relative to mean) required to apply the bonus. Below
+            this, the bass signal is too flat to trust and the window
+            falls back to full-spectrum-only matching.
 
     Returns:
         List of ChordEvent instances, sorted by start_time.
@@ -158,6 +191,25 @@ def estimate_chord_progression(
         dtype=np.float64,
     )
 
+    # Pre-compute each template's root pitch class for the bass-bonus
+    # lookup. Indexed by template position in _TEMPLATE_LABELS. Computed
+    # whether or not bass_chroma_frames is provided — cheap and avoids
+    # branching the hot loop.
+    template_root_pcs = np.array(
+        [_root_pitch_class(label) for label in _TEMPLATE_LABELS],
+        dtype=np.int64,
+    )
+
+    # Bass-aware estimation requires the time axes to match. Misaligned
+    # shapes mean the caller mixed window indices that don't correspond —
+    # we silently fall back to full-spectrum-only rather than crash, which
+    # matches the fail-soft posture of the rest of the audio pipeline.
+    use_bass = (
+        bass_chroma_frames is not None
+        and bass_chroma_frames.ndim == 2
+        and bass_chroma_frames.shape == local_chroma_frames.shape
+    )
+
     # --- Sliding window similarity ---
     num_windows = 1 + (T - win_frames) // hop_frames
     raw_labels: List[int] = []  # index into _TEMPLATE_LABELS
@@ -183,6 +235,34 @@ def estimate_chord_progression(
         # Tonal bias: bump diatonic templates
         if effective_tonal_bias > 0:
             similarities = similarities + effective_tonal_bias * template_is_diatonic
+
+        # Bass-aware bonus: identify the dominant bass pitch class for
+        # this window and bump templates whose root matches. Confidence-
+        # gated so silent / flat-bass windows don't push noise into the
+        # match. Cheaper to compute peakiness than entropy and good
+        # enough for the "is there a clear bass note here?" question.
+        if use_bass and bass_bonus > 0:
+            assert bass_chroma_frames is not None  # mypy hint; use_bass implies this
+            bass_window = bass_chroma_frames[:, start:end]
+            bass_avg = bass_window.mean(axis=1)
+            bass_norm = np.linalg.norm(bass_avg)
+            if bass_norm > 0:
+                bass_avg = bass_avg / bass_norm
+                bass_max = float(bass_avg.max())
+                bass_mean = float(bass_avg.mean())
+                # Peakiness: how much the dominant PC sticks out above the
+                # mean. Range roughly [0, 1]. A pure single-note bass hits
+                # ~0.95; a triad in the bass register sits around 0.4-0.6;
+                # a flat (silent or noisy) window stays under 0.2.
+                bass_confidence = (
+                    (bass_max - bass_mean) / (bass_max + 1e-9) if bass_max > 0 else 0.0
+                )
+                if bass_confidence >= bass_confidence_threshold:
+                    bass_pc = int(bass_avg.argmax())
+                    root_match_mask = (template_root_pcs == bass_pc).astype(np.float64)
+                    similarities = similarities + (
+                        bass_bonus * bass_confidence * root_match_mask
+                    )
 
         best_idx = int(np.argmax(similarities))
         best_score = float(similarities[best_idx])

--- a/src/harmonic_analysis/audio/_io.py
+++ b/src/harmonic_analysis/audio/_io.py
@@ -292,3 +292,127 @@ def extract_local_chroma(
     # without runtime overhead on the happy path.
     assert local_chroma is not None, "local_chroma unset — neither branch ran"
     return local_chroma
+
+
+# C2 is roughly 65 Hz, B3 is roughly 245 Hz — that's two octaves of bass
+# register, which covers electric/acoustic bass guitar, piano left hand,
+# upright bass, kick-drum tonals, and most synth bass voices. Going lower
+# than C2 starts catching room rumble and HVAC; going higher than B3 starts
+# catching guitar voicings and weakens the "this is the chord root"
+# inference. Both magic constants come from MIR literature on bass chroma.
+_BASS_FMIN_NOTE = "C2"
+_BASS_N_OCTAVES = 2
+
+
+def extract_local_bass_chroma(
+    filepath: PathLike,
+    *,
+    start_time: float = 0.0,
+    end_time: Optional[float] = None,
+) -> np.ndarray:
+    """Bass-register chroma for the same time window as ``extract_local_chroma``.
+
+    Computes ``chroma_cqt`` with ``fmin`` set to C2 and ``n_octaves`` set to
+    2, focusing the analysis on the bass register where chord roots
+    actually live. Same streaming/in-memory split, same padding behavior,
+    same hop length — frames align with ``extract_local_chroma`` output so
+    you can index into both with the same window indices.
+
+    Why a separate function instead of an option on ``extract_local_chroma``:
+    keeping the two-pass shape explicit at the call site means the chord
+    estimator's "I want both" intent is obvious, and it avoids regressing
+    callers that only need the full-spectrum chroma. The cost is a second
+    pass through the file — measurable on long files but typically <100 ms
+    for songs under ~5 minutes. See `process/audio-chord-estimation.md`
+    for the algorithm rationale.
+
+    Args:
+        filepath: Same as ``extract_local_chroma``.
+        start_time: Same.
+        end_time: Same.
+
+    Returns:
+        ``np.ndarray`` shape ``(12, T)``. Same time axis as
+        ``extract_local_chroma`` for the same ``(start_time, end_time)``.
+        Each column is the bass-register chroma at one frame.
+
+    Raises:
+        Same as ``extract_local_chroma`` — passes through the underlying
+        librosa/soundfile errors and the empty-segment ValueError.
+    """
+    bass_fmin = float(librosa.note_to_hz(_BASS_FMIN_NOTE))
+
+    with sf.SoundFile(str(filepath), "r") as f:
+        sr = f.samplerate
+        file_duration_sec = len(f) / float(sr)
+
+    segment_start_sec = float(start_time)
+    if end_time is not None and end_time <= file_duration_sec:
+        segment_end_sec = float(end_time)
+    else:
+        segment_end_sec = file_duration_sec
+    segment_duration_sec = segment_end_sec - segment_start_sec
+
+    if segment_duration_sec <= 0:
+        raise ValueError("The specified segment is empty or out of bounds.")
+
+    start_sample = librosa.time_to_samples(segment_start_sec, sr=sr)
+    end_sample = librosa.time_to_samples(segment_end_sec, sr=sr)
+    num_samples_to_read = int(end_sample - start_sample)
+
+    if num_samples_to_read <= 0:
+        raise ValueError("The specified segment is empty or out of bounds.")
+
+    chunk_size = sr * _CHUNK_SIZE_SECONDS
+    bass_chroma: Optional[np.ndarray] = None
+
+    if segment_duration_sec > LOCAL_ANALYSIS_STREAMING_THRESHOLD_S:
+        bass_chroma_list: list[np.ndarray] = []
+        with sf.SoundFile(str(filepath), "r") as f:
+            f.seek(int(start_sample))
+            samples_processed = 0
+            while samples_processed < num_samples_to_read:
+                samples_this_chunk = min(
+                    chunk_size, num_samples_to_read - samples_processed
+                )
+                block = f.read(samples_this_chunk, dtype="float32", always_2d=True)
+                if not block.size:
+                    break
+                y_chunk = np.mean(block.T, axis=0)
+                samples_processed += len(block)
+                chunk_len = len(y_chunk)
+                if chunk_len == 0:
+                    continue
+                if chunk_len < MIN_SAMPLES_FOR_CQT:
+                    pad_width = MIN_SAMPLES_FOR_CQT - chunk_len
+                    y_chunk = np.pad(y_chunk, (0, pad_width), "constant")
+                chunk_chroma = librosa.feature.chroma_cqt(
+                    y=y_chunk,
+                    sr=sr,
+                    fmin=bass_fmin,
+                    n_octaves=_BASS_N_OCTAVES,
+                )
+                bass_chroma_list.append(chunk_chroma)
+        if not bass_chroma_list:
+            raise ValueError("Could not process the local segment (no audio read).")
+        bass_chroma = np.concatenate(bass_chroma_list, axis=1)
+    else:
+        with sf.SoundFile(str(filepath), "r") as f:
+            f.seek(int(start_sample))
+            y_segment_frames = f.read(
+                num_samples_to_read, dtype="float32", always_2d=True
+            )
+            y_segment = np.mean(y_segment_frames.T, axis=0)
+            segment_len = len(y_segment)
+            if segment_len < MIN_SAMPLES_FOR_CQT:
+                pad_width = MIN_SAMPLES_FOR_CQT - segment_len
+                y_segment = np.pad(y_segment, (0, pad_width), "constant")
+            bass_chroma = librosa.feature.chroma_cqt(
+                y=y_segment,
+                sr=sr,
+                fmin=bass_fmin,
+                n_octaves=_BASS_N_OCTAVES,
+            )
+
+    assert bass_chroma is not None, "bass_chroma unset — neither branch ran"
+    return bass_chroma

--- a/src/harmonic_analysis/integrations/audio_adapter.py
+++ b/src/harmonic_analysis/integrations/audio_adapter.py
@@ -184,6 +184,8 @@ class AudioAdapter:
         chord_window_size_s: float = 0.5,
         chord_hop_size_s: float = 0.25,
         tonal_bias: float = 0.15,
+        use_bass_chroma: bool = False,
+        bass_bonus: float = 0.3,
     ) -> None:
         """Initialize the adapter.
 
@@ -227,6 +229,8 @@ class AudioAdapter:
         self._chord_window_size_s = chord_window_size_s
         self._chord_hop_size_s = chord_hop_size_s
         self._tonal_bias = tonal_bias
+        self._use_bass_chroma = use_bass_chroma
+        self._bass_bonus = bass_bonus
 
         if not quiet and not self.ffmpeg_available:
             # Single WARNING — informational, not a fail. WAV still works.
@@ -344,6 +348,19 @@ class AudioAdapter:
                 estimate_chord_progression,
             )
 
+            # Bass-aware estimation: extract a parallel bass-register
+            # chroma and pass it to the estimator. Disambiguates relative
+            # pairs (Bm vs D, Am vs C) when the bass note is the
+            # discriminating signal. Costs a second chroma pass over the
+            # audio — typically <100ms for songs under ~5 minutes.
+            bass_chroma = None
+            if self._use_bass_chroma:
+                from harmonic_analysis.audio._io import extract_local_bass_chroma
+
+                bass_chroma = extract_local_bass_chroma(
+                    filepath, start_time=resolved_start, end_time=resolved_end
+                )
+
             chords = estimate_chord_progression(
                 local_chroma,
                 global_key,
@@ -352,6 +369,8 @@ class AudioAdapter:
                 window_size_s=self._chord_window_size_s,
                 hop_size_s=self._chord_hop_size_s,
                 tonal_bias=self._tonal_bias,
+                bass_chroma_frames=bass_chroma,
+                bass_bonus=self._bass_bonus,
             )
 
         return AudioAnalysisResult(
@@ -374,6 +393,8 @@ def analyze_audio(
     chord_window_size_s: float = 0.5,
     chord_hop_size_s: float = 0.25,
     tonal_bias: float = 0.15,
+    use_bass_chroma: bool = False,
+    bass_bonus: float = 0.3,
 ) -> AudioAnalysisResult:
     """Synchronous convenience wrapper around ``AudioAdapter.from_audio``.
 
@@ -404,6 +425,8 @@ def analyze_audio(
         chord_window_size_s=chord_window_size_s,
         chord_hop_size_s=chord_hop_size_s,
         tonal_bias=tonal_bias,
+        use_bass_chroma=use_bass_chroma,
+        bass_bonus=bass_bonus,
     )
     return adapter.from_audio(filepath, segment=segment)
 
@@ -417,6 +440,8 @@ async def analyze_audio_async(
     chord_window_size_s: float = 0.5,
     chord_hop_size_s: float = 0.25,
     tonal_bias: float = 0.15,
+    use_bass_chroma: bool = False,
+    bass_bonus: float = 0.3,
 ) -> AudioAnalysisResult:
     """Async convenience wrapper. Offloads librosa work to a worker thread.
 
@@ -448,4 +473,6 @@ async def analyze_audio_async(
         chord_window_size_s=chord_window_size_s,
         chord_hop_size_s=chord_hop_size_s,
         tonal_bias=tonal_bias,
+        use_bass_chroma=use_bass_chroma,
+        bass_bonus=bass_bonus,
     )

--- a/tests/integration/test_toolkit_wrapper_recipe.py
+++ b/tests/integration/test_toolkit_wrapper_recipe.py
@@ -1,0 +1,98 @@
+"""Regression test: the documented toolkit wrapper recipe must actually work.
+
+Reads docs/how-to/audio-analysis.md, extracts the sentinel-tagged code fence,
+runs it against a synthetic WAV, and asserts the result has all ModeAnalysisResponse
+required fields. The doc IS the test fixture — no copy-paste duplication.
+"""
+
+import textwrap
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+librosa = pytest.importorskip("librosa")
+sf = pytest.importorskip("soundfile")
+
+
+# Path to the how-to doc (the test fixture)
+HOWTO_PATH = (
+    Path(__file__).resolve().parents[2] / "docs" / "how-to" / "audio-analysis.md"
+)
+
+SENTINEL_START = "# toolkit-wrapper-recipe-start"
+SENTINEL_END = "# toolkit-wrapper-recipe-end"
+
+
+def _extract_recipe(howto_path: Path) -> str:
+    """Parse the markdown, find the sentinel-tagged fence, return the code."""
+    text = howto_path.read_text()
+    lines = text.splitlines()
+    start_idx = None
+    end_idx = None
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == SENTINEL_START:
+            start_idx = i
+        elif stripped == SENTINEL_END:
+            end_idx = i
+            break
+    assert start_idx is not None, f"Sentinel start not found in {howto_path}"
+    assert end_idx is not None, f"Sentinel end not found in {howto_path}"
+    recipe_lines = lines[start_idx + 1 : end_idx]
+    return textwrap.dedent("\n".join(recipe_lines))
+
+
+def _make_synthetic_wav(path: Path, duration: float = 2.0, sr: int = 22050) -> None:
+    """Generate a sine-wave WAV. Not music, but enough to exercise the pipeline."""
+    t = np.linspace(0, duration, int(sr * duration), endpoint=False)
+    # A4 = 440 Hz — recognizable enough for key estimation to latch onto something
+    signal = 0.5 * np.sin(2 * np.pi * 440 * t)
+    sf.write(str(path), signal, sr)
+
+
+@pytest.mark.asyncio
+async def test_toolkit_wrapper_recipe_produces_valid_result(tmp_path):
+    """The documented recipe must produce a dict with all ModeAnalysisResponse fields."""
+    # Generate synthetic WAV
+    wav_path = tmp_path / "test_tone.wav"
+    _make_synthetic_wav(wav_path)
+
+    # Extract recipe from the doc — the doc is the single source of truth,
+    # so if the recipe drifts from what the test expects, we find out here
+    # instead of in production.
+    recipe_code = _extract_recipe(HOWTO_PATH)
+
+    # Run the recipe in a controlled namespace. We use compile+exec because
+    # the recipe defines an async function (run_wrapper) that we then call.
+    # This is NOT the same as running arbitrary user input — the source is
+    # our own checked-in documentation file.
+    namespace = {"audio_path": str(wav_path)}
+    compiled = compile(recipe_code, "<toolkit-wrapper-recipe>", "exec")
+    # Safe: source is our own docs/how-to/audio-analysis.md, not user input
+    exec(compiled, namespace)  # noqa: S102
+
+    # The recipe must define an async function we can call. Since exec can't
+    # await top-level async code, the recipe defines
+    # `async def run_wrapper(audio_path)` that returns result_dict.
+    assert "run_wrapper" in namespace, (
+        "Recipe must define 'async def run_wrapper(audio_path)' "
+        "that returns a ModeAnalysisResponse-shaped dict"
+    )
+    result_dict = await namespace["run_wrapper"](str(wav_path))
+
+    # Assert all ModeAnalysisResponse required fields
+    assert isinstance(result_dict["global"]["tonic"], str)
+    assert isinstance(result_dict["global"]["mode"], str)
+    assert isinstance(result_dict["local"]["region_type"], str)
+    assert isinstance(result_dict["analysis"]["borrowed_tones"], list)
+    assert isinstance(result_dict["analysis"]["cadence_detected"], bool)
+
+    # chromagram_summary: list of exactly 12 floats
+    chroma = result_dict["analysis"]["chromagram_summary"]
+    assert isinstance(chroma, list)
+    assert len(chroma) == 12
+    assert all(isinstance(v, float) for v in chroma)
+
+    # visuals: list (may be empty)
+    assert isinstance(result_dict["visuals"], list)


### PR DESCRIPTION
## Summary
- Audio file analysis support via `POST /api/analyze/audio` REST endpoint with chord events and key estimates (#31)
- `[audio]` optional extra for audio-to-harmony analysis powered by librosa/soundfile
- Comprehensive Diátaxis documentation: tutorial, how-to, API reference, and architecture explanation
- Toolkit wrapper recipe with regression test ensuring zero documentation drift

## Metadata
- **Scope:** audio_processing_integration-04
- **Build:** build/4
- **Beta:** v0.3.1-beta.1

## Test plan
- [ ] Pre-commit hooks pass (black, isort, flake8, mypy)
- [ ] `pytest tests/ -v --tb=short` passes
- [ ] `POST /api/analyze/audio` returns valid JSON
- [ ] Documentation links resolve correctly

Closes #31