### PR TITLE
chore(release): prepare v0.3.1-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.3.1-beta.2] - 2026-05-05
+
 ### Added
 
 - **Bass-aware chord estimation** — new `use_bass_chroma` parameter on `analyze_audio`, `analyze_audio_async`, and `AudioAdapter` (default `False`) for disambiguating slash chords and inversions (e.g., Bm vs D/B). When enabled, low-frequency chroma frames bias template-match scoring toward chords whose root or third matches the detected bass note.
 - **Rubato temporal flexibility** — new `rubato` parameter on the same three audio APIs accepting four named presets (`"strict"`, `"moderate"`, `"loose"`, `"free"`) or a float in `[0.0, 1.0]` that interpolates between preset window/hop/median-kernel triples. Default `"moderate"` matches previous behavior exactly. Unknown strings raise `ValueError`.
+- **Real-audio regression tests** — four integration tests against a real piano recording (`iwasonce_steinway.mp3`) guard against the relative-pair mix-up re-emerging. Approach-level unit tests for boundary filtering and cadential parity also added, because lightning can strike twice.
 
 ### Fixed
 
 - **Phantom chord events during silent audio** — analysis windows whose chroma L2 norm falls below the new `min_chroma_norm=0.05` threshold are now skipped, eliminating spurious chord detections in leading silence and quiet sections. Soft-attack content above threshold continues to produce chord events with correct timestamps.
+- **Relative minor/major key confusion in audio analysis** — the ensemble key detector was picking D Ionian (the relative major) when the recording was clearly in B Aeolian. Two culprits caught and corrected: `boundary_chords` was letting garbage low-confidence edge events vote, and `cadential` was giving V→I full credit while treating V→i like a distant cousin. Both now play fair. Real recordings in minor keys finally get their due. (#34)
 
 ### Changed
 

--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -5,6 +5,41 @@ the good stuff — what you can actually *do* now — lives here.
 
 ---
 
+## [0.3.1-beta.2] - 2026-05-05
+
+### 🔧 Fixed: The "Minor Key Identity Crisis" Is Over
+
+🎹 **No more B minor misidentified as D major.** If you've been feeding real recordings into the
+key detector and getting the relative major back instead of the actual minor key — this one's for
+you. Two bugs in the ensemble detector were conspiring against minor keys: low-quality edge events
+were getting to vote on the key, and the V→i cadence (minor resolution!) was being scored as less
+convincing than V→I. Both are fixed. Recordings in minor keys now get their due.
+
+### ✨ New Things You Can Do
+
+🎸 **Disambiguate slash chords and inversions with bass-chroma analysis.** New `use_bass_chroma`
+parameter on `analyze_audio` and `AudioAdapter` (default `False`). When enabled, the chord
+estimator uses low-frequency chroma to bias matching toward chords whose root or third lines up
+with the detected bass note — so Bm and D/B stop being the same thing. Opt-in because it costs
+a bit extra and not every recording has clean bass separation.
+
+⏲️ **Tune the analysis for how loosely the recording was played.** New `rubato` parameter accepts
+`"strict"`, `"moderate"`, `"loose"`, or `"free"` (or a float from 0.0 to 1.0). Rubato controls
+the analysis window size and smoothing — a free-tempo piano performance needs different settings
+than a click-tracked studio take. Default is `"moderate"`, which matches the previous behavior
+exactly, so you won't notice a thing unless you opt in.
+
+### 🛠️ Under the Hood
+
+🔇 **Silence is no longer a chord.** Leading silence and quiet sections used to generate phantom
+chord events; they don't anymore. Analysis windows below the minimum chroma energy threshold are
+skipped entirely. Your timestamps will actually mean something now.
+
+📊 **Real-audio regression tests** now guard the relative-pair fix. Four integration tests run
+against a real piano recording and will loudly object if B minor starts coming back as D major again.
+
+---
+
 ## [0.3.1-beta.1] - 2026-05-05
 
 ### ✨ New Things You Can Do

--- a/demo/backend/rest_api/models.py
+++ b/demo/backend/rest_api/models.py
@@ -7,7 +7,7 @@ These models provide automatic validation, serialization, and OpenAPI documentat
 
 from __future__ import annotations
 
-from typing import Any, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -260,5 +260,64 @@ class AudioAnalysisResponse(BaseModel):
     analysis: _AnalysisModel
     chord_progression: List[ChordEventModel]
     segment: _SegmentModel
+    key_analysis_details: Optional["KeyAnalysisDetails"] = None
 
     model_config = {"populate_by_name": True}
+
+
+# Diagnostic-panel models. The route returns Dict[str, Any], so these
+# exist to document the shape and feed OpenAPI. Same loose-typing pattern
+# as the rest of the audio response models above.
+
+
+class _RankedKey(BaseModel):
+    """One row in an approach's top_3 ranking — KeyInfo + score."""
+
+    key: _KeyInfoModel
+    score: float
+
+
+class KeyApproachDetail(BaseModel):
+    """One approach's contribution to the diagnostic panel.
+
+    Each approach reports its name, the weight applied during synthesis,
+    and the top-3 candidates it produced. The full ranked list lives in
+    the synthesis ``key_score_table`` — top_3 is what humans look at first.
+    """
+
+    name: str = Field(description="Approach identifier, e.g. 'template_correlation'")
+    weight: float = Field(description="Weight applied to this approach's votes")
+    top_3: List[_RankedKey] = Field(
+        default_factory=list,
+        description="Top-3 (KeyInfo, score) candidates from this approach",
+    )
+
+
+class SynthesisDetail(BaseModel):
+    """Synthesizer's output for the diagnostic panel.
+
+    Mirrors ``SynthesisResult`` but uses dict-of-floats for the score
+    table so the JSON response can be parsed without custom decoders.
+    """
+
+    method: str = Field(description="Synthesis method, e.g. 'weighted_sum'")
+    winner: _KeyInfoModel
+    runner_up: Optional[_KeyInfoModel] = None
+    margin: float = Field(description="winner_total - runner_up_total")
+    key_score_table: Dict[str, float] = Field(
+        default_factory=dict,
+        description="All candidates' summed weighted scores, keyed by key_signature",
+    )
+
+
+class KeyAnalysisDetails(BaseModel):
+    """Top-level diagnostic-panel payload.
+
+    Populated only when the request includes ``show_details=true``.
+    iteration_01 doesn't ship HMM segmentation, so ``modulations`` is
+    always None for now.
+    """
+
+    approaches: List[KeyApproachDetail] = Field(default_factory=list)
+    synthesis: SynthesisDetail
+    modulations: Optional[List[dict]] = None

--- a/demo/backend/rest_api/routes.py
+++ b/demo/backend/rest_api/routes.py
@@ -7,6 +7,7 @@ These routes handle chord/roman/melody/scale analysis plus file uploads.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import tempfile
@@ -419,6 +420,9 @@ async def analyze_audio_endpoint(
     file: UploadFile = File(...),
     start: Optional[float] = Form(None),
     end: Optional[float] = Form(None),
+    show_details: bool = Form(False),
+    key_detection: str = Form("default"),
+    key_ensemble_weights: Optional[str] = Form(None),
 ) -> Dict[str, Any]:
     """
     Analyze an audio file (WAV, MP3, etc.) for key, chords, and cadences.
@@ -426,6 +430,16 @@ async def analyze_audio_endpoint(
     Opening move: Accept audio upload, run the library's audio pipeline.
     Main play: Build a JSON-safe response dict (no frozensets allowed).
     Victory lap: Return key estimation, chord progression, and cadence info.
+
+    New form fields (audio_score_alignment-02):
+        show_details: When ``true``, response includes ``key_analysis_details``
+            with per-approach breakdown. Default ``false`` keeps the wire
+            format unchanged for existing clients.
+        key_detection: Ensemble preset (``"default"``, ``"ks_only"``,
+            ``"full"``) or JSON-encoded list/dict for fine control. Default
+            is the four-approach ensemble.
+        key_ensemble_weights: Optional JSON object mapping approach name
+            to weight, overriding the preset's defaults.
     """
     # Import guard — audio deps are optional; fail loudly with install hint
     try:
@@ -443,6 +457,51 @@ async def analyze_audio_endpoint(
     if not file.filename:
         raise HTTPException(status_code=400, detail="No filename provided")
 
+    # Parse key_detection. Accept the three preset strings directly; if the
+    # caller sends something else, try parsing as JSON (list or dict). Bad
+    # input gets a 400 with a useful message — failing fast here beats
+    # surfacing a deep ValueError from the library at analysis time.
+    valid_presets = {"default", "ks_only", "full"}
+    parsed_key_detection: Any
+    if key_detection in valid_presets:
+        parsed_key_detection = key_detection
+    else:
+        # Maybe a JSON list or dict?
+        try:
+            parsed_key_detection = json.loads(key_detection)
+        except json.JSONDecodeError:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Invalid key_detection value {key_detection!r}. "
+                    f"Valid presets: {sorted(valid_presets)}, or a JSON-encoded "
+                    f"list of approach names or {{name: weight}} dict."
+                ),
+            )
+
+    # Parse the optional weights override.
+    parsed_weights: Optional[Dict[str, float]] = None
+    if key_ensemble_weights is not None:
+        try:
+            raw = json.loads(key_ensemble_weights)
+        except json.JSONDecodeError:
+            raise HTTPException(
+                status_code=400,
+                detail="key_ensemble_weights must be a JSON object {name: weight}.",
+            )
+        if not isinstance(raw, dict):
+            raise HTTPException(
+                status_code=400,
+                detail="key_ensemble_weights must be a JSON object {name: weight}.",
+            )
+        try:
+            parsed_weights = {str(k): float(v) for k, v in raw.items()}
+        except (TypeError, ValueError):
+            raise HTTPException(
+                status_code=400,
+                detail="key_ensemble_weights values must all be numeric.",
+            )
+
     # Main play: save uploaded file to temp location (same pattern as /analyze/file)
     temp_dir = tempfile.gettempdir()
     temp_file_path = os.path.join(temp_dir, f"audio_{file.filename}")
@@ -455,12 +514,23 @@ async def analyze_audio_endpoint(
         # Build segment tuple if the caller specified a window
         segment = (start, end) if start is not None else None
 
-        result = await analyze_audio_async(temp_file_path, segment=segment)
+        try:
+            result = await analyze_audio_async(
+                temp_file_path,
+                segment=segment,
+                key_detection=parsed_key_detection,
+                show_analysis_details=show_details,
+                key_ensemble_weights=parsed_weights,
+            )
+        except ValueError as exc:
+            # resolve_preset() raises ValueError for unknown presets
+            # passed via the JSON-decoded path. Surface as 400.
+            raise HTTPException(status_code=400, detail=str(exc))
 
         # Victory lap: build the response dict MANUALLY.
         # Never use asdict() here — KeyInfo.diatonic_pitch_classes is a
         # frozenset and will 500 the entire response. Ask me how I know.
-        return {
+        response: Dict[str, Any] = {
             "global": {
                 "tonic": result.global_key.tonic,
                 "mode": result.global_key.mode,
@@ -495,6 +565,14 @@ async def analyze_audio_endpoint(
                 "end": result.segment_end,
             },
         }
+
+        # Conditionally include the diagnostic panel. When show_details is
+        # off, the response shape is unchanged from the pre-ensemble
+        # contract — this is what AC-07's backward-compat case checks.
+        if show_details and result.key_analysis_details is not None:
+            response["key_analysis_details"] = result.key_analysis_details
+
+        return response
 
     except AudioImportError:
         raise HTTPException(

--- a/docs/explanation/audio-analysis-internals.md
+++ b/docs/explanation/audio-analysis-internals.md
@@ -110,6 +110,72 @@ The default of `0.05` was chosen to be conservative:
 
 If your recordings have unusual noise floors (e.g., a live concert with ambient crowd noise, or a recording with a persistent hum), you may need to raise the threshold. Conversely, if you are analyzing extremely quiet passages and losing chord events, lower it toward `0.0` — but expect some phantom labels to creep back in.
 
+## Why Ensemble Key Detection
+
+### The Relative-Pair Problem
+
+Krumhansl-Schmuckler is fundamentally a pitch-class-set classifier. Two keys with identical pitch-class sets — D major and B minor share `{D, E, F#, G, A, B, C#}` — produce indistinguishable chroma vectors when averaged over time. K-S has no way to break the tie except via the absolute strength of each pitch class in the chroma, and that's just a quirk of voicing density. The recording can audibly be in B minor (starts and ends on Bm, V→i cadences throughout, bass on B) and K-S will still confidently return D major because the time-averaged chroma slightly favors D.
+
+This isn't a tuning bug. The K-S algorithm is doing exactly what it was designed to do; the design just doesn't model the *function* of pitches, only their statistical distribution. The fix isn't a smarter K-S — it's adding orthogonal evidence that *can* tell relative pairs apart.
+
+### The Ensemble Approach
+
+Instead of betting everything on one signal, the audio pipeline runs an ensemble of independent approaches that vote on the final verdict:
+
+| Approach | What it sees | Why it helps with relative pairs |
+|----------|--------------|----------------------------------|
+| `template_correlation` (K-S) | Time-averaged chroma | The baseline. Fails on relative pairs |
+| `boundary_chords` | First and last chord events | Real tonal music starts/ends on tonic. Bm bookends → B Aeolian |
+| `bass_dominance` | Bass-register chroma | Bass note ≠ chord root in many cases, but for tonic chords, bass note *is* the tonic |
+| `cadential` | Chord-event sequence | V→I and V→i are the harmonic punctuation. Counts the cadences |
+
+A `KeyEnsembleSynthesizer` (in `_key_ensemble.py`) takes each approach's ranked candidates, multiplies by per-approach weights, and sums into a single score table. The winner of that table is the final `global_key`.
+
+### Two-Stage Orchestration
+
+The chord estimator needs a key (for `tonal_bias`), and the chord-event-based approaches need chord events. That circularity gets resolved in two stages:
+
+1. Run `template_correlation` alone on the global chroma → `ks_key`.
+2. Use `ks_key` to bias chord estimation → chord events.
+3. Run the full ensemble (with chord events available) → `ensemble_key`.
+4. `result.global_key = ensemble_key`.
+
+The chord estimator's `tonal_bias` keeps using the K-S result, not the ensemble winner. For relative pairs this is lossless because both keys share the same diatonic set — the diatonic templates that get the bias bonus are identical either way.
+
+### Why These Four Approaches as Defaults
+
+The four iteration_01 defaults were chosen because they're cheap, deterministic, and decorrelated:
+
+- **`template_correlation`** is the only approach with weight ≥ 1.0 because it's the only one that uses the full chroma signal directly. Everyone else is a corrective.
+- **`boundary_chords`** has high weight (0.8) because in tonal music, opening and closing chords are *the* most reliable tonic signal. The exceptions (anacruses, fade-outs) don't usually mislead the verdict — they just produce slightly weaker signal.
+- **`bass_dominance`** has lower weight (0.6) because bass voicings can be inverted, pedaled, or genre-typical in ways that distract from the literal tonic.
+- **`cadential`** has middle weight (0.7) because it produces strong signal *when it fires* but only fires on actual V→I cadences. The chord estimator only outputs major/minor triads (no V7), so we lose some discriminative power compared to a tracker that recognized dominant-7th chords.
+
+The weights are intuition-derived starting points, not corpus-tuned values. Empirical tuning against a labeled corpus is a follow-up scope.
+
+### Performance Budgets
+
+The ensemble adds modest overhead to the audio pipeline:
+
+- **Defaults on:** < 1.5x the K-S-only baseline. Chord-event scanning is cheap; bass-chroma extraction is a second `librosa.cqt` pass that runs in well under 100ms for typical audio.
+- **`pattern_engine` on (iteration_02):** < 2x. The pattern engine runs once per top-K candidate key, not all 24 — bounded cost.
+- **`hmm` on (iteration_02):** < 3x. Viterbi over 24 states × N frames. Linear in audio length, but with a substantial constant factor.
+
+The diagnostic panel itself adds ~10–20% overhead because it builds the per-approach top_3 lists; synthesis is essentially free compared to chroma extraction.
+
+### Why Pattern Engine and HMM Are Opt-In
+
+`pattern_engine` and `hmm_segmentation` ship in iteration_02 as **opt-in** rather than default for two reasons:
+
+- **Performance.** Pattern engine adds 2x; HMM adds 3x. Production callers analyzing thousands of files don't want that overhead by default.
+- **Tuning sensitivity.** HMM transition probabilities are hand-picked from music-theory intuition. The default matrix works for "one or two key changes per piece" but struggles on rapidly modulating jazz or chromatic classical. Until those defaults are tuned against a real corpus, defaulting them on would be a footgun.
+
+The architecture is forward-compatible: callers can opt in via `key_detection="full"` or `key_detection=["template_correlation", "pattern_engine", "hmm"]` once iteration_02 lands. The `KeyDetectionApproach` protocol is fixed, so the iteration_01 defaults don't need to change when the opt-ins ship.
+
+### Backward Compatibility
+
+`key_detection="ks_only"` reproduces the pre-ensemble code path exactly. The `find_best_key` import path still works — it's now a one-liner that delegates to the `TemplateCorrelationApproach.detect()` call. AC-02 of audio_score_alignment-02 asserts bit-identical results to 4 decimal places.
+
 ## See Also
 
 - [Audio API Reference](../reference/audio-api.md) — field-by-field documentation

--- a/docs/how-to/audio-analysis.md
+++ b/docs/how-to/audio-analysis.md
@@ -198,6 +198,107 @@ result = await analyze_audio_async("live_recording.wav", min_chroma_norm=0.10)
 
 The default (`0.05`) is conservative: it catches genuine silence and room tone while preserving *pianissimo* dynamics. Raise it if you see suspicious chord labels during quiet passages; lower it (toward `0.0`) only if you are losing legitimate soft chords.
 
+## How to Debug a Wrong Key Verdict
+
+If the analyzer returns a key that doesn't match what you hear in the recording — D major when you swear it's in B minor, for instance — the relative-pair confusion problem is usually the culprit. The audio pipeline ships an ensemble of independent key-detection approaches that vote on the verdict; turning on the diagnostic panel shows you why each approach voted the way it did.
+
+### Step 1: Enable `show_analysis_details`
+
+```python
+from harmonic_analysis import analyze_audio_async
+
+result = await analyze_audio_async(
+    "song.wav",
+    show_analysis_details=True,
+)
+
+print(f"Verdict: {result.global_key.tonic} {result.global_key.mode}")
+for approach in result.key_analysis_details["approaches"]:
+    print(f"\n{approach['name']} (weight={approach['weight']}):")
+    for entry in approach["top_3"]:
+        key = entry["key"]
+        print(f"  {key['tonic']} {key['mode']:<8}  score={entry['score']:.3f}")
+
+synth = result.key_analysis_details["synthesis"]
+print(f"\nSynthesis: {synth['winner']['tonic']} {synth['winner']['mode']} "
+      f"(runner-up: {synth['runner_up']['tonic']} {synth['runner_up']['mode']}, "
+      f"margin: {synth['margin']:.3f})")
+```
+
+### Step 2: Read the panel
+
+A typical "wrong K-S, right ensemble" pattern looks like this:
+
+```
+template_correlation (weight=1.0):
+  D Ionian        score=0.930
+  F# Aeolian      score=0.884
+  B Aeolian       score=0.882
+
+boundary_chords (weight=0.8):
+  B Aeolian       score=0.714
+  B Ionian        score=0.357
+  E Ionian        score=0.286
+
+bass_dominance (weight=0.6):
+  B Ionian        score=0.179
+  B Aeolian       score=0.179
+  F# Ionian       score=0.170
+
+cadential (weight=0.7):
+  D Ionian        score=1.000
+  G Aeolian       score=1.000
+  B Aeolian       score=1.000
+
+Synthesis: B Aeolian (runner-up: D Ionian, margin: 0.483)
+```
+
+K-S alone returns D Ionian with high confidence — that's the relative-pair problem. The boundary_chords approach correctly notices the song starts and ends on Bm; bass_dominance sees B in the bass; cadential picks up the V→i pattern. Together they outweigh K-S and the synthesis lands on B Aeolian.
+
+### Step 3: Override weights if needed
+
+If the default weights don't suit your repertoire (e.g., a corpus where boundary chords are unreliable but the bass is rock-solid), pass custom weights:
+
+```python
+result = await analyze_audio_async(
+    "song.wav",
+    show_analysis_details=True,
+    key_ensemble_weights={
+        "boundary_chords": 0.4,  # weaker
+        "bass_dominance": 1.2,   # stronger
+    },
+)
+```
+
+Approaches not listed retain their default weight; the override is additive, not replacement.
+
+### Step 4: Compare against `ks_only`
+
+To see what the pre-ensemble code path would have returned:
+
+```python
+ks_result = await analyze_audio_async("song.wav", key_detection="ks_only")
+print(f"K-S only: {ks_result.global_key.tonic} {ks_result.global_key.mode}")
+```
+
+This is the migration backstop — if your test suite previously asserted D major on a recording that's audibly B minor, the assertion was actually checking K-S behavior, and you can pin it via `key_detection="ks_only"` while the rest of your code uses the ensemble.
+
+### CLI Workflow
+
+The same diagnostic flow works from the command line:
+
+```bash
+python scripts/try_audio.py song.wav --show-analysis-details
+
+# Override weights from the CLI
+python scripts/try_audio.py song.wav --show-analysis-details \
+    --ensemble-weights '{"boundary_chords": 0.4, "bass_dominance": 1.2}'
+
+# Compare ensemble vs K-S-only on the same file
+python scripts/try_audio.py song.wav
+python scripts/try_audio.py song.wav --key-detection ks_only
+```
+
 ## See Also
 
 - **[Audio Quick Start Tutorial](../tutorials/audio-quickstart.md)** — 5-minute hands-on introduction

--- a/docs/reference/audio-api.md
+++ b/docs/reference/audio-api.md
@@ -4,7 +4,7 @@ Field-by-field reference for the audio analysis surface. For the core pattern an
 
 ## Module-Level Convenience Functions
 
-### `analyze_audio(path, *, segment=None, quiet=False, include_chords=True, chord_window_size_s=None, chord_hop_size_s=None, tonal_bias=0.15, rubato="moderate", use_bass_chroma=False, bass_bonus=0.3, min_chroma_norm=0.05)`
+### `analyze_audio(path, *, segment=None, quiet=False, include_chords=True, chord_window_size_s=None, chord_hop_size_s=None, tonal_bias=0.15, rubato="moderate", use_bass_chroma=False, bass_bonus=0.3, min_chroma_norm=0.05, key_detection="default", show_analysis_details=False, key_ensemble_weights=None)`
 
 Synchronous convenience wrapper. Constructs a fresh `AudioAdapter` per call — cheap, the only real work in construction is an ffmpeg-on-PATH check.
 
@@ -23,14 +23,17 @@ Synchronous convenience wrapper. Constructs a fresh `AudioAdapter` per call — 
 | `use_bass_chroma` | `bool` | `False` | Enable bass-aware chord estimation using a second chroma extraction focused on low frequencies |
 | `bass_bonus` | `float` | `0.3` | Maximum bonus added to template cosine similarity when the chord root matches the bass chroma peak. Scaled per-window by bass-chroma confidence so noisy bass detections contribute less. Only effective when `use_bass_chroma=True` |
 | `min_chroma_norm` | `float` | `0.05` | Minimum L2 norm threshold for chord detection windows. Windows below this norm are treated as silence and produce no chord label |
+| `key_detection` | `str \| list[str] \| dict[str, float]` | `"default"` | Ensemble preset (`"default"`, `"ks_only"`, `"full"`), explicit list of approach names, or `{name: weight}` dict. See [Key Detection Ensemble](#key-detection-ensemble) below |
+| `show_analysis_details` | `bool` | `False` | When `True`, populates `result.key_analysis_details` with per-approach breakdown for debugging |
+| `key_ensemble_weights` | `dict[str, float] \| None` | `None` | Optional override mapping approach name → weight; replaces preset defaults |
 
 **Returns:** `AudioAnalysisResult`
 
 **Raises:**
 - `AudioImportError` — if `librosa` or `soundfile` are not installed
-- `ValueError` — for empty or too-short segments
+- `ValueError` — for empty or too-short segments, unknown `key_detection` preset names, empty list/dict `key_detection` specs
 
-### `analyze_audio_async(path, *, segment=None, quiet=False, include_chords=True, chord_window_size_s=None, chord_hop_size_s=None, tonal_bias=0.15, rubato="moderate", use_bass_chroma=False, bass_bonus=0.3, min_chroma_norm=0.05)`
+### `analyze_audio_async(path, *, segment=None, quiet=False, include_chords=True, chord_window_size_s=None, chord_hop_size_s=None, tonal_bias=0.15, rubato="moderate", use_bass_chroma=False, bass_bonus=0.3, min_chroma_norm=0.05, key_detection="default", show_analysis_details=False, key_ensemble_weights=None)`
 
 Async convenience wrapper. Uses `asyncio.to_thread` to keep the blocking librosa work off the event loop. Same parameters and return type as `analyze_audio`.
 
@@ -49,6 +52,9 @@ Async convenience wrapper. Uses `asyncio.to_thread` to keep the blocking librosa
 | `use_bass_chroma` | `bool` | `False` | Enable bass-aware chord estimation using a second chroma extraction focused on low frequencies |
 | `bass_bonus` | `float` | `0.3` | Maximum bonus added to template cosine similarity when the chord root matches the bass chroma peak. Scaled per-window by bass-chroma confidence so noisy bass detections contribute less. Only effective when `use_bass_chroma=True` |
 | `min_chroma_norm` | `float` | `0.05` | Minimum L2 norm threshold for chord detection windows. Windows below this norm are treated as silence and produce no chord label |
+| `key_detection` | `str \| list[str] \| dict[str, float]` | `"default"` | See [Key Detection Ensemble](#key-detection-ensemble) below |
+| `show_analysis_details` | `bool` | `False` | Populate `result.key_analysis_details` with per-approach breakdown |
+| `key_ensemble_weights` | `dict[str, float] \| None` | `None` | Override per-approach weights |
 
 ## `AudioAdapter`
 
@@ -113,13 +119,14 @@ The top-level result returned by `analyze_audio` and `AudioAdapter.from_audio`.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `global_key` | `KeyInfo` | K-S key estimate over the whole file |
-| `local_key` | `KeyInfo` | K-S key estimate over the analyzed segment |
+| `global_key` | `KeyInfo` | Ensemble key estimate over the whole file (was K-S only before iteration 02) |
+| `local_key` | `KeyInfo` | Key estimate over the analyzed segment |
 | `cadences` | `CadenceInfo` | V-I cadence detection result |
 | `region` | `RegionInfo` | Region classification (stable / modulation / modal_shift) |
 | `chords` | `list[ChordEvent]` | Timestamped chord events (empty if `include_chords=False`) |
 | `segment_start` | `float` | Start of analyzed segment in seconds |
 | `segment_end` | `float` | End of analyzed segment in seconds |
+| `key_analysis_details` | `dict \| None` | Per-approach diagnostic payload — `None` unless `show_analysis_details=True`. See [Key Analysis Details Schema](#key-analysis-details-schema) |
 
 **Properties:**
 
@@ -188,6 +195,76 @@ try:
 except AudioImportError:
     print("Install with: pip install harmonic-analysis[audio]")
 ```
+
+## Key Detection Ensemble
+
+As of audio_score_alignment-02, the audio pipeline uses an ensemble of independent key-detection approaches that vote on the final key verdict. The single-algorithm Krumhansl-Schmuckler estimator can't reliably tell relative major/minor pairs apart (D Ionian vs B Aeolian have identical pitch-class sets); orthogonal evidence from boundary chords, bass dominance, and cadential motion breaks those ties.
+
+### Approach Catalog (iteration_01)
+
+| Approach | Default? | Default weight | What it does |
+|----------|----------|----------------|--------------|
+| `template_correlation` | Yes | 1.0 | The original K-S correlation against pitch-class profiles. Foundational; everyone else breaks its ties |
+| `boundary_chords` | Yes | 0.8 | Scores keys by whether the first/last chord events match the candidate's tonic (or dominant) |
+| `bass_dominance` | Yes | 0.6 | Aggregates the bass chroma over the whole segment, scores keys by tonic + dominant emphasis |
+| `cadential` | Yes | 0.7 | Counts V→I (major) / V→i (minor) transitions in the chord-event sequence |
+| `pattern_engine` | No (iteration_02) | 0.9 | Calls `PatternAnalysisService` per top-K candidate key; returns its confidence |
+| `hmm` | No (iteration_02) | 0.5 | Viterbi over a 24-state key HMM; produces local-key segments for modulating music |
+
+### Presets
+
+The `key_detection` parameter accepts these preset strings:
+
+- `"default"` — runs `template_correlation`, `boundary_chords`, `bass_dominance`, and `cadential`. The recommended setting for most use cases.
+- `"ks_only"` — runs only `template_correlation`. Mirrors the pre-ensemble code path; use this to recover the exact behavior of versions before audio_score_alignment-02.
+- `"full"` — runs every approach including the iteration_02 opt-ins. Currently equivalent to `"default"` until iteration_02 ships the opt-ins.
+
+You can also pass an explicit list of approach names (`["template_correlation", "boundary_chords"]`) or a dict mapping name → weight (`{"template_correlation": 1.5, "cadential": 0.0}`).
+
+### Two-Stage Orchestration
+
+The chord estimator needs a key (for `tonal_bias`), and the chord-event-based approaches (`boundary_chords`, `cadential`) need chord events. The pipeline resolves this circularity in two stages:
+
+1. **Stage 1:** Run `template_correlation` alone on the global chroma → `ks_key`.
+2. **Stage 2:** Use `ks_key` to bias chord estimation. Output: chord events.
+3. **Stage 3:** Run the full ensemble with chord events available. Output: `ensemble_key`.
+4. **Stage 4:** `result.global_key = ensemble_key`.
+
+The chord estimator's `tonal_bias` still uses the stage-1 K-S result (not the ensemble winner). For relative pairs this is lossless because both keys share the same diatonic set.
+
+### Key Analysis Details Schema
+
+When `show_analysis_details=True`, `result.key_analysis_details` is populated with this structure:
+
+```python
+{
+    "approaches": [
+        {
+            "name": "template_correlation",
+            "weight": 1.0,
+            "top_3": [
+                {"key": {"tonic": "B", "mode": "Aeolian", ...}, "score": 0.957},
+                ...
+            ],
+        },
+        # ... one entry per enabled approach
+    ],
+    "synthesis": {
+        "method": "weighted_sum",
+        "winner": {"tonic": "B", "mode": "Aeolian", ...},
+        "runner_up": {"tonic": "D", "mode": "Ionian", ...},
+        "margin": 0.483,
+        "key_score_table": {"B Aeolian": 2.51, "D Ionian": 2.03, ...},
+    },
+    "modulations": None,  # iteration_02 will populate this when HMM is on
+}
+```
+
+When `show_analysis_details=False` (the default), `result.key_analysis_details is None` — no payload bloat for production callers.
+
+### Backward Compatibility
+
+The old `find_best_key` import path (`from harmonic_analysis.audio._key_estimation import find_best_key`) still works and produces bit-identical results to pre-ensemble behavior. To get the same end-to-end behavior as before the ensemble shipped, pass `key_detection="ks_only"`.
 
 ## See Also
 

--- a/scripts/try_audio.py
+++ b/scripts/try_audio.py
@@ -10,6 +10,8 @@ Usage:
     python scripts/try_audio.py path/to/your.wav --start 0 --end 30
     python scripts/try_audio.py --synth  # generate + analyze /tmp/a_major.wav
     python scripts/try_audio.py path/to/your.wav --json # raw JSON-ish dump
+    python scripts/try_audio.py path/to/your.wav --show-analysis-details
+    python scripts/try_audio.py path/to/your.wav --key-detection ks_only
 
 Requires: pip install -e ".[audio]"  (librosa + soundfile)
 """
@@ -20,7 +22,7 @@ import asyncio
 import json
 import sys
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Dict, Optional, Union
 
 
 def _make_synth_wav(path: Path, duration: float = 5.0, sr: int = 22050) -> Path:
@@ -72,11 +74,83 @@ def _print_human(result) -> None:
     else:
         print("chords       : none detected")
 
+    # Diagnostic panel — only populated when --show-analysis-details was set.
+    details = getattr(result, "key_analysis_details", None)
+    if details:
+        _print_analysis_panel(details)
+
+
+def _print_analysis_panel(details: Dict[str, Any]) -> None:
+    """Render the per-approach breakdown as a human-friendly table."""
+    print()
+    print("=" * 64)
+    print("KEY ANALYSIS DETAILS")
+    print("=" * 64)
+
+    approaches = details.get("approaches", [])
+    if approaches:
+        # Header. Width chosen so most approach names + a 3-row top-3
+        # block fit cleanly in 80-column terminals.
+        print(f"{'Approach':<24} {'Weight':>7}  Top 3 Candidates")
+        print("-" * 64)
+        for a in approaches:
+            name = a.get("name", "?")
+            weight = a.get("weight", 0.0)
+            top_3 = a.get("top_3", [])
+            # First top-3 row on the same line as the approach name.
+            if top_3:
+                first = top_3[0]
+                key_str = (
+                    f"{first['key']['tonic']} {first['key']['mode']}"
+                    if isinstance(first.get("key"), dict)
+                    else str(first.get("key"))
+                )
+                print(
+                    f"{name:<24} {weight:>7.2f}  "
+                    f"1) {key_str:<14} score={first['score']:.3f}"
+                )
+                for i, entry in enumerate(top_3[1:], start=2):
+                    key_str = (
+                        f"{entry['key']['tonic']} {entry['key']['mode']}"
+                        if isinstance(entry.get("key"), dict)
+                        else str(entry.get("key"))
+                    )
+                    print(
+                        f"{'':<24} {'':>7}  "
+                        f"{i}) {key_str:<14} score={entry['score']:.3f}"
+                    )
+            else:
+                # Empty ranked list (e.g. cadential with no V→I cadences).
+                print(f"{name:<24} {weight:>7.2f}  (no candidates)")
+            print()
+
+    synth = details.get("synthesis")
+    if synth:
+        print("-" * 64)
+        print("Synthesis:")
+        winner = synth.get("winner") or {}
+        winner_str = f"{winner.get('tonic', '?')} {winner.get('mode', '?')}"
+        print(f"  method      : {synth.get('method')}")
+        print(f"  winner      : {winner_str}")
+        runner = synth.get("runner_up")
+        if runner:
+            runner_str = f"{runner.get('tonic', '?')} {runner.get('mode', '?')}"
+            print(f"  runner-up   : {runner_str}")
+        margin = synth.get("margin")
+        if margin is not None:
+            print(f"  margin      : {margin:.3f}")
+
+    if details.get("modulations"):
+        print(
+            f"  modulations : {len(details['modulations'])} segment(s) "
+            f"(see HMM section)"
+        )
+
 
 def _to_json(result) -> dict:
     """Manual dict construction. asdict() chokes on KeyInfo's frozenset
     field — same trap the route dodges. Don't reach for asdict here."""
-    return {
+    payload: Dict[str, Any] = {
         "global": {
             "tonic": result.global_key.tonic,
             "mode": result.global_key.mode,
@@ -113,6 +187,10 @@ def _to_json(result) -> dict:
             for c in result.chords
         ],
     }
+    details = getattr(result, "key_analysis_details", None)
+    if details is not None:
+        payload["key_analysis_details"] = details
+    return payload
 
 
 async def _run(
@@ -126,6 +204,9 @@ async def _run(
     bass_chroma: bool,
     bass_bonus: float,
     rubato: Union[str, float] = "moderate",
+    key_detection: Union[str, list, dict] = "default",
+    show_analysis_details: bool = False,
+    key_ensemble_weights: Optional[Dict[str, float]] = None,
 ) -> int:
     try:
         from harmonic_analysis import analyze_audio_async
@@ -147,6 +228,9 @@ async def _run(
         use_bass_chroma=bass_chroma,
         bass_bonus=bass_bonus,
         rubato=rubato,
+        key_detection=key_detection,
+        show_analysis_details=show_analysis_details,
+        key_ensemble_weights=key_ensemble_weights,
     )
 
     if as_json:
@@ -234,6 +318,34 @@ def main() -> int:
         dest="bass_bonus",
         help="bass-root-match bonus when --bass-chroma is on (default 0.3)",
     )
+    # Ensemble key-detection knobs (audio_score_alignment-02).
+    # --key-detection accepts presets or a JSON list of approach names.
+    # --ensemble-weights takes a JSON object mapping approach name → weight.
+    # --show-analysis-details renders the per-approach diagnostic panel.
+    parser.add_argument(
+        "--show-analysis-details",
+        action="store_true",
+        dest="show_analysis_details",
+        help="emit the per-approach diagnostic panel (text or JSON)",
+    )
+    parser.add_argument(
+        "--key-detection",
+        default="default",
+        dest="key_detection",
+        help=(
+            "ensemble preset (default | ks_only | full) or a JSON list of "
+            'approach names (e.g. \'["template_correlation","boundary_chords"]\')'
+        ),
+    )
+    parser.add_argument(
+        "--ensemble-weights",
+        default=None,
+        dest="ensemble_weights",
+        help=(
+            "JSON object overriding default per-approach weights, "
+            'e.g. \'{"template_correlation": 1.5, "boundary_chords": 0.5}\''
+        ),
+    )
     args = parser.parse_args()
 
     if args.synth:
@@ -269,6 +381,54 @@ def main() -> int:
     except ValueError:
         rubato_val = rubato_raw
 
+    # Parse key_detection. Preset strings pass through; everything else
+    # tries JSON. This matches the route's behavior so the CLI and HTTP
+    # surfaces stay symmetric.
+    valid_presets = {"default", "ks_only", "full"}
+    key_det_arg: Union[str, list, dict]
+    if args.key_detection in valid_presets:
+        key_det_arg = args.key_detection
+    else:
+        try:
+            key_det_arg = json.loads(args.key_detection)
+        except json.JSONDecodeError as exc:
+            print(
+                f"error: --key-detection must be a preset "
+                f"({', '.join(sorted(valid_presets))}) or JSON list/dict; "
+                f"got {args.key_detection!r} ({exc})",
+                file=sys.stderr,
+            )
+            return 2
+
+    # Parse --ensemble-weights. None passes through unchanged.
+    parsed_weights: Optional[Dict[str, float]] = None
+    if args.ensemble_weights is not None:
+        try:
+            raw_weights = json.loads(args.ensemble_weights)
+        except json.JSONDecodeError as exc:
+            print(
+                f"error: --ensemble-weights must be a JSON object "
+                f"like '{{\"approach_name\": 1.0}}'; got {args.ensemble_weights!r} "
+                f"({exc})",
+                file=sys.stderr,
+            )
+            return 2
+        if not isinstance(raw_weights, dict):
+            print(
+                "error: --ensemble-weights must be a JSON object, not a "
+                f"{type(raw_weights).__name__}",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            parsed_weights = {str(k): float(v) for k, v in raw_weights.items()}
+        except (TypeError, ValueError):
+            print(
+                "error: --ensemble-weights values must all be numeric",
+                file=sys.stderr,
+            )
+            return 2
+
     return asyncio.run(
         _run(
             args.filepath,
@@ -281,6 +441,9 @@ def main() -> int:
             args.bass_chroma,
             args.bass_bonus,
             rubato=rubato_val,
+            key_detection=key_det_arg,
+            show_analysis_details=args.show_analysis_details,
+            key_ensemble_weights=parsed_weights,
         )
     )
 

--- a/src/harmonic_analysis/audio/_key_approaches/__init__.py
+++ b/src/harmonic_analysis/audio/_key_approaches/__init__.py
@@ -1,0 +1,38 @@
+"""Key-detection approach implementations.
+
+Each module exports one class implementing ``KeyDetectionApproach``. The
+adapter-level orchestrator picks which ones to run based on the
+``key_detection`` parameter; this package just provides the toolbox.
+
+iteration_01 ships four defaults; iteration_02 adds ``pattern_engine``
+and ``hmm`` opt-ins.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from .._key_ensemble import KeyDetectionApproach
+from .bass_dominance import BassDominanceApproach
+from .boundary_chords import BoundaryChordsApproach
+from .cadential import CadentialApproach
+from .template_correlation import TemplateCorrelationApproach
+
+__all__ = [
+    "BassDominanceApproach",
+    "BoundaryChordsApproach",
+    "CadentialApproach",
+    "TemplateCorrelationApproach",
+    "DEFAULT_APPROACH_REGISTRY",
+]
+
+
+# Name → class lookup. The adapter consults this to instantiate approaches
+# by name (string-driven) rather than by import. Adding a new approach is
+# a one-line registration; old call sites keep working.
+DEFAULT_APPROACH_REGISTRY: Dict[str, Type[KeyDetectionApproach]] = {
+    "template_correlation": TemplateCorrelationApproach,
+    "boundary_chords": BoundaryChordsApproach,
+    "bass_dominance": BassDominanceApproach,
+    "cadential": CadentialApproach,
+}

--- a/src/harmonic_analysis/audio/_key_approaches/bass_dominance.py
+++ b/src/harmonic_analysis/audio/_key_approaches/bass_dominance.py
@@ -1,0 +1,128 @@
+"""Bass-dominance scoring approach.
+
+The bass register tells you what the listener perceives as the tonic
+much more reliably than the time-averaged full-spectrum chroma. K-S
+sees Bm and D major as identical pitch-class sets — both contain
+{B, D, F#, ...}. The bass register, on the other hand, screams "B" in
+the Bm case and "D" in the D-major case.
+
+This approach takes the bass chroma vector (already extracted by
+``_io.extract_local_bass_chroma`` and time-averaged), normalizes it,
+and scores each key by how much the tonic and dominant pitch classes
+dominate. A pure single-bass-note recording produces a sharp peak; a
+walking-bass-line recording produces a more diffuse pattern.
+
+Empty bass_chroma_1d: returns an empty ranked list. Synthesizer treats
+this as "no opinion" — same contract as the other approaches.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import numpy as np
+
+from .._key_ensemble import (
+    KeyDetectionApproach,
+    KeyDetectionContext,
+    KeyDetectionVerdict,
+)
+from .._profiles import PITCH_CLASSES
+from .._types import KeyInfo
+
+# Bass scoring weights. Tonic is the dominant signal in the bass; the
+# perfect 5th below tonic (= dominant) is the second strongest. Mediant
+# bass tones happen but rarely dominate.
+_TONIC_BASS_WEIGHT = 1.0
+_DOMINANT_BASS_WEIGHT = 0.4
+
+
+class BassDominanceApproach(KeyDetectionApproach):
+    """Score keys by how strongly the bass emphasizes tonic + dominant.
+
+    The bass chroma is already 12-bin (octaves collapsed). Each candidate
+    key receives a score = tonic_weight * bass[tonic_pc] + dominant_weight
+    * bass[dominant_pc], normalized by the bass vector's L1 norm so the
+    output sits in [0, 1].
+    """
+
+    name: str = "bass_dominance"
+
+    def detect(self, ctx: KeyDetectionContext) -> KeyDetectionVerdict:
+        """Score each of 24 keys by bass-chroma weighting.
+
+        Args:
+            ctx: KeyDetectionContext. Consults ``bass_chroma_1d`` only.
+
+        Returns:
+            KeyDetectionVerdict with up to 24 ranked candidates. When
+            ``bass_chroma_1d`` is None, returns an empty ranked list.
+        """
+        bass = ctx.bass_chroma_1d
+        if bass is None:
+            return KeyDetectionVerdict(
+                name=self.name,
+                ranked=[],
+                meta={"reason": "no_bass_chroma"},
+            )
+
+        bass_arr = np.asarray(bass, dtype=float)
+        if bass_arr.shape != (12,):
+            # Defensive — caller passed something other than a 12-vector.
+            # Don't crash the whole ensemble; downgrade to "no opinion".
+            return KeyDetectionVerdict(
+                name=self.name,
+                ranked=[],
+                meta={"reason": f"bad_bass_shape:{bass_arr.shape}"},
+            )
+
+        # Normalize so scoring is invariant to overall bass loudness.
+        # Some bass-quiet recordings still have a perfectly clear bass
+        # *pattern* — we want the relative emphasis, not absolute energy.
+        total = float(bass_arr.sum())
+        if total <= 0:
+            return KeyDetectionVerdict(
+                name=self.name,
+                ranked=[],
+                meta={"reason": "zero_bass_energy"},
+            )
+        normalized = bass_arr / total
+
+        ranked: List[Tuple[KeyInfo, float]] = []
+
+        # Max raw score = sum of weights (tonic and dominant fully claimed).
+        max_raw = _TONIC_BASS_WEIGHT + _DOMINANT_BASS_WEIGHT
+
+        for tonic_pc, tonic_name in enumerate(PITCH_CLASSES):
+            dominant_pc = (tonic_pc + 7) % 12
+
+            tonic_share = float(normalized[tonic_pc])
+            dominant_share = float(normalized[dominant_pc])
+
+            raw_score = (
+                _TONIC_BASS_WEIGHT * tonic_share
+                + _DOMINANT_BASS_WEIGHT * dominant_share
+            )
+            score = raw_score / max_raw if max_raw > 0 else 0.0
+
+            for mode_label in ("Ionian", "Aeolian"):
+                key_is_minor = mode_label == "Aeolian"
+                key_str = f"{tonic_name} {'major' if not key_is_minor else 'minor'}"
+                key_info = KeyInfo(
+                    tonic=tonic_name,
+                    mode=mode_label,
+                    key_signature=key_str,
+                    confidence=round(score, 4),
+                )
+                ranked.append((key_info, score))
+
+        ranked.sort(key=lambda pair: pair[1], reverse=True)
+
+        return KeyDetectionVerdict(
+            name=self.name,
+            ranked=ranked,
+            meta={
+                "dominant_bass_pc": int(np.argmax(normalized)),
+                "bass_distribution": normalized.tolist(),
+            },
+        )

--- a/src/harmonic_analysis/audio/_key_approaches/boundary_chords.py
+++ b/src/harmonic_analysis/audio/_key_approaches/boundary_chords.py
@@ -1,0 +1,255 @@
+"""Boundary-chord scoring approach.
+
+Music theory's most reliable signal for "what key is this in" is what
+the piece starts and ends on. The first and last chord events of a tonal
+piece are usually i/I (with a v-i or V-I just before the close). Real
+recordings violate this — anacruses, fade-outs, modal pivots — but the
+first/last sample is still strong evidence on aggregate.
+
+This approach scores each candidate (tonic, mode) by checking whether the
+first and last chord events match either the tonic or the dominant of
+that key. Tonic match gets the full score; dominant match gets a smaller
+bonus (the V→i bookend pattern is common, especially in classical).
+
+Empty chord_events: returns an empty ranked list. The synthesizer treats
+this as "no opinion" and the approach contributes nothing to the total.
+This is the graceful-degradation contract documented in
+KeyDetectionApproach.
+
+Real-audio gotcha (iteration_01_a fix): the chord estimator faithfully
+emits events for silent lead-in and trailing decay, where it has no real
+harmonic content to score. Those low-confidence/short-duration events
+reflect tonal_bias defaulting to the global K-S key, not actual played
+chords. We filter by ``min_confidence`` and ``min_duration_s`` before
+selecting boundaries so the approach scores on chords the performer
+actually played, not the chord estimator's nervous tic on room tone.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+from .._key_ensemble import (
+    KeyDetectionApproach,
+    KeyDetectionContext,
+    KeyDetectionVerdict,
+)
+from .._profiles import PITCH_CLASSES
+from .._types import KeyInfo
+
+# Score weights for the boundary check. Tonic match is worth more than
+# dominant match — a tonic ending is the canonical resolution. These
+# values are intuition-derived; they only need to be relative since the
+# synthesizer applies the per-approach weight on top.
+_TONIC_BONUS = 1.0
+_DOMINANT_BONUS = 0.4
+
+# Default thresholds for filtering boundary-eligible events. Surfaced
+# as instance fields so callers can tune them without source edits.
+# 0.85 sits well above the ~0.82 of silent-lead-in K-S fallback artifacts
+# and well below the 0.94+ of real sustained chords. 0.5s filters
+# momentary decay-tail events without rejecting legitimately brief endings.
+_DEFAULT_MIN_CONFIDENCE = 0.85
+_DEFAULT_MIN_DURATION_S = 0.5
+
+
+def _root_pitch_class(chord_label: str) -> Optional[int]:
+    """Extract pitch-class index from a chord label.
+
+    Handles 'C', 'C#', 'Cm', 'C#m', 'Bm', etc. Returns None for unparseable
+    labels so callers don't have to wrap in try/except.
+    """
+    # Strip trailing 'm' for minor; preserve sharps. The chord estimator
+    # only outputs major/minor triads (no extensions, no slash chords),
+    # so this simple peel is sufficient.
+    root_name = chord_label.rstrip("m") if chord_label.endswith("m") else chord_label
+    try:
+        return PITCH_CLASSES.index(root_name)
+    except ValueError:
+        return None
+
+
+def _is_minor_label(chord_label: str) -> bool:
+    """True if the chord is minor (e.g. 'Am', 'Bm', 'F#m')."""
+    return chord_label.endswith("m")
+
+
+class BoundaryChordsApproach(KeyDetectionApproach):
+    """Score keys by first/last chord event matching tonic or dominant.
+
+    The "first" event is the first chord_events entry that meets both
+    ``min_confidence`` AND ``min_duration_s`` thresholds; "last" is the
+    last such entry. Pre-filtering keeps the chord estimator's silent-
+    lead-in and trailing-decay artifacts from poisoning the boundary
+    signal — those events have low confidence (~0.82) and/or short
+    duration (<0.5s) compared to legitimately played chords (>=0.94
+    confidence, >=1s sustained).
+
+    We do NOT respect the time bounds beyond duration filtering because
+    the chord estimator already consolidates consecutive identical
+    labels, so the first qualifying event IS the opening section's
+    chord (post-silence).
+    """
+
+    name: str = "boundary_chords"
+    # Instance-level configuration. Defaults match the locked spec from
+    # the iteration_01_a fix; subclasses or call sites can override
+    # without rewriting this module.
+    min_confidence: float = _DEFAULT_MIN_CONFIDENCE
+    min_duration_s: float = _DEFAULT_MIN_DURATION_S
+
+    def __init__(
+        self,
+        min_confidence: float = _DEFAULT_MIN_CONFIDENCE,
+        min_duration_s: float = _DEFAULT_MIN_DURATION_S,
+    ) -> None:
+        """Construct with optional threshold overrides.
+
+        Args:
+            min_confidence: Minimum chord-event confidence to qualify
+                as a boundary signal. Default 0.85 — above silent-
+                lead-in artifacts (~0.82), below real chords (>=0.94).
+            min_duration_s: Minimum sustained duration (end - start)
+                in seconds to qualify. Default 0.5s — filters momentary
+                decay-tail noise without rejecting legitimate brief
+                endings.
+        """
+        self.min_confidence = min_confidence
+        self.min_duration_s = min_duration_s
+
+    def detect(self, ctx: KeyDetectionContext) -> KeyDetectionVerdict:
+        """Score each of 24 keys by boundary-chord match.
+
+        Args:
+            ctx: KeyDetectionContext. Consults ``chord_events`` only.
+
+        Returns:
+            KeyDetectionVerdict with up to 24 ranked candidates. When
+            chord_events is None, empty, or has no events meeting
+            both threshold filters, returns an empty ranked list with
+            ``meta["reason"]`` populated (synthesizer treats this as
+            "no opinion").
+        """
+        events = ctx.chord_events
+        if not events:
+            # Graceful degradation — empty list, not a crash.
+            return KeyDetectionVerdict(
+                name=self.name,
+                ranked=[],
+                meta={"reason": "no_chord_events"},
+            )
+
+        # Filter to events that look like real played chords. We compute
+        # duration on the fly because ChordEvent doesn't carry a
+        # duration_s attribute — it's just (end - start). getattr() with
+        # defaults keeps the protocol structural; fakes in tests don't
+        # need to grow new fields to pass.
+        qualifying = [
+            e
+            for e in events
+            if getattr(e, "confidence", 0.0) >= self.min_confidence
+            and (getattr(e, "end_time", 0.0) - getattr(e, "start_time", 0.0))
+            >= self.min_duration_s
+        ]
+
+        if not qualifying:
+            # All events failed at least one threshold — typical of an
+            # all-noise input or a recording where the chord estimator
+            # was running on near-silent chroma the whole time.
+            return KeyDetectionVerdict(
+                name=self.name,
+                ranked=[],
+                meta={
+                    "reason": "no_qualifying_events",
+                    "min_confidence": self.min_confidence,
+                    "min_duration_s": self.min_duration_s,
+                    "events_seen": len(events),
+                },
+            )
+
+        # Pull off the first and last QUALIFYING events. Single-event
+        # qualifying sequences mean opener == closer, which is fine —
+        # the score just doubles the tonic match for that one chord.
+        first_chord = qualifying[0]
+        last_chord = qualifying[-1]
+
+        first_label = getattr(first_chord, "chord_label", None)
+        last_label = getattr(last_chord, "chord_label", None)
+
+        first_pc = _root_pitch_class(first_label) if first_label else None
+        last_pc = _root_pitch_class(last_label) if last_label else None
+        first_minor = _is_minor_label(first_label) if first_label else False
+        last_minor = _is_minor_label(last_label) if last_label else False
+
+        # Normalize raw scores into [0,1] for the synthesizer. Max
+        # possible raw score is 2 * _TONIC_BONUS (both ends match tonic
+        # AND quality) — see scoring loop below.
+        max_raw = 2 * (_TONIC_BONUS + _DOMINANT_BONUS)
+
+        ranked: List[Tuple[KeyInfo, float]] = []
+
+        for tonic_pc, tonic_name in enumerate(PITCH_CLASSES):
+            for mode_label in ("Ionian", "Aeolian"):
+                key_is_minor = mode_label == "Aeolian"
+                # Dominant pitch class is the perfect 5th above tonic.
+                # Pop convention; works for both major and minor keys.
+                dominant_pc = (tonic_pc + 7) % 12
+
+                raw = 0.0
+
+                # First-chord scoring
+                if first_pc is not None:
+                    if first_pc == tonic_pc:
+                        # Bonus is full when the chord quality also matches
+                        # the key's tonic chord (major key → major chord,
+                        # minor key → minor chord). Wrong-quality matches
+                        # still count — Picardy thirds and modal pivots
+                        # exist — but at reduced weight.
+                        if first_minor == key_is_minor:
+                            raw += _TONIC_BONUS
+                        else:
+                            raw += _TONIC_BONUS * 0.5
+                    elif first_pc == dominant_pc:
+                        # Dominant openings are rarer but happen (V-I-IV
+                        # sequences). Quality match check less strict —
+                        # V is major in both keys.
+                        raw += _DOMINANT_BONUS
+
+                # Last-chord scoring (mirror of first)
+                if last_pc is not None:
+                    if last_pc == tonic_pc:
+                        if last_minor == key_is_minor:
+                            raw += _TONIC_BONUS
+                        else:
+                            raw += _TONIC_BONUS * 0.5
+                    elif last_pc == dominant_pc:
+                        raw += _DOMINANT_BONUS
+
+                normalized = raw / max_raw if max_raw > 0 else 0.0
+
+                key_str = f"{tonic_name} {'major' if not key_is_minor else 'minor'}"
+                key_info = KeyInfo(
+                    tonic=tonic_name,
+                    mode=mode_label,
+                    key_signature=key_str,
+                    confidence=round(normalized, 4),
+                )
+                ranked.append((key_info, normalized))
+
+        ranked.sort(key=lambda pair: pair[1], reverse=True)
+
+        return KeyDetectionVerdict(
+            name=self.name,
+            ranked=ranked,
+            meta={
+                # These reflect the QUALIFYING boundaries used for
+                # scoring, not the raw events[0] / events[-1]. The
+                # diagnostic panel's job is to show what the approach
+                # actually scored against, otherwise the silent-lead-in
+                # bug we just fixed becomes invisible again.
+                "first_chord": first_label,
+                "last_chord": last_label,
+                "qualifying_count": len(qualifying),
+                "events_seen": len(events),
+            },
+        )

--- a/src/harmonic_analysis/audio/_key_approaches/cadential.py
+++ b/src/harmonic_analysis/audio/_key_approaches/cadential.py
@@ -1,0 +1,191 @@
+"""Cadential V→i / V→I scoring approach.
+
+Cadences are the strongest functional signal in tonal music — they're
+literally the harmonic punctuation that establishes "here's the tonic."
+Scanning the chord event sequence for V→I (major key) and V→i (minor
+key) transitions, then scoring each candidate key by how many of its
+diagnostic cadences appear, is one of the most musically grounded ways
+to break a relative-pair tie.
+
+Limitations honestly disclosed:
+    * The chord estimator only recognizes major/minor triads. No V7
+      (which would be a stronger cadential signal). No diminished VII°
+      either.
+    * We score perfect cadences (V→I or V→i) only. Plagal (IV→I),
+      deceptive (V→vi), and half-cadences are treated as non-events
+      because they're ambiguous between candidate keys.
+
+iteration_01_a fix — mode-agnostic crediting:
+    Cadential's job is to identify *which tonic root* receives a
+    cadential resolution. It is NOT cadential's job to pre-decide major
+    vs. minor — that's what the synthesizer + bass_dominance + K-S
+    template fit do, with orthogonal evidence. The previous code
+    branched on the tonic chord's quality and credited only the matching
+    mode (Ionian for major tonic, Aeolian for minor tonic), which
+    produced a silent major-bias bug: F#→Bm (a textbook minor authentic
+    cadence — V in minor is always major) scored zero for B Aeolian on
+    real recordings. We now credit BOTH Ionian and Aeolian slots equally
+    when a major-V resolves to any tonic chord; the rest of the ensemble
+    sorts mode out.
+
+Empty chord_events: returns an empty ranked list — graceful degradation
+contract.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+from .._key_ensemble import (
+    KeyDetectionApproach,
+    KeyDetectionContext,
+    KeyDetectionVerdict,
+)
+from .._profiles import PITCH_CLASSES
+from .._types import KeyInfo
+
+
+def _root_pitch_class(chord_label: str) -> Optional[int]:
+    """Extract pitch-class index from a chord label, or None."""
+    root_name = chord_label.rstrip("m") if chord_label.endswith("m") else chord_label
+    try:
+        return PITCH_CLASSES.index(root_name)
+    except ValueError:
+        return None
+
+
+def _is_minor_label(chord_label: str) -> bool:
+    """True if the chord is minor (e.g. 'Am', 'Bm', 'F#m')."""
+    return chord_label.endswith("m")
+
+
+class CadentialApproach(KeyDetectionApproach):
+    """Score keys by counting major-V → tonic resolutions (mode-agnostic).
+
+    Walks the chord_events list looking for adjacent (a, b) pairs where
+    ``a`` is a major triad whose root is the dominant of ``b``'s root.
+    When found, both Ionian and Aeolian candidates of the resolved tonic
+    receive equal credit — cadential identifies that there's a cadence
+    on this tonic root, not which parallel-mode the piece is in.
+
+    For each (major V → tonic) pair we credit:
+        cadence_counts[tonic_pc * 2]     += 1   # Ionian slot
+        cadence_counts[tonic_pc * 2 + 1] += 1   # Aeolian slot
+
+    The score is the cadence count divided by the maximum observed count
+    across all keys, normalized to [0, 1]. A key with no cadences scores
+    zero; the key with the most cadences scores 1.0. Because Ionian and
+    Aeolian of the same tonic always increment together, they always
+    appear with equal score in the ranked output — the synthesizer +
+    bass_dominance + K-S sort out which mode is actually right.
+    """
+
+    name: str = "cadential"
+
+    def detect(self, ctx: KeyDetectionContext) -> KeyDetectionVerdict:
+        """Score each of 24 keys by cadential evidence.
+
+        Args:
+            ctx: KeyDetectionContext. Consults ``chord_events`` only.
+
+        Returns:
+            KeyDetectionVerdict. Empty ranked list when chord_events is
+            absent or empty.
+        """
+        events = ctx.chord_events
+        if not events or len(events) < 2:
+            # Need at least a transition. One chord can't cadence.
+            return KeyDetectionVerdict(
+                name=self.name,
+                ranked=[],
+                meta={"reason": "insufficient_chord_events"},
+            )
+
+        # Pre-extract (root_pc, is_minor) pairs for every event we can
+        # parse. Unparseable labels become None and don't contribute to
+        # any cadence pair.
+        parsed: List[Optional[Tuple[int, bool]]] = []
+        for ev in events:
+            label = getattr(ev, "chord_label", None)
+            if not label:
+                parsed.append(None)
+                continue
+            pc = _root_pitch_class(label)
+            if pc is None:
+                parsed.append(None)
+                continue
+            parsed.append((pc, _is_minor_label(label)))
+
+        # Score per (tonic_pc, mode) candidate. Stored in a 24-element
+        # array indexed (tonic_pc * 2 + minor_flag).
+        cadence_counts: List[int] = [0] * 24
+
+        for i in range(len(parsed) - 1):
+            a = parsed[i]
+            b = parsed[i + 1]
+            if a is None or b is None:
+                continue
+
+            a_pc, a_minor = a
+            b_pc, _b_minor = b  # b's quality intentionally ignored — see below
+
+            # 'a' must be a major triad to function as a dominant.
+            # The chord estimator only outputs major/minor triads; minor
+            # dominants are theoretically possible but vanishingly rare
+            # in tonal repertoire and we don't credit them here.
+            if a_minor:
+                continue
+
+            # Walk all 12 tonic candidates; credit equally for both
+            # Ionian and Aeolian when a is the dominant of tonic_pc and
+            # b lands on tonic_pc (regardless of b's quality).
+            for tonic_pc in range(12):
+                expected_dominant_pc = (tonic_pc + 7) % 12
+                if a_pc != expected_dominant_pc or b_pc != tonic_pc:
+                    continue
+
+                # Mode-agnostic dual credit. Both Ionian and Aeolian of
+                # the same tonic root get +1 because cadential can't
+                # (and shouldn't) tell parallel-mode apart from a single
+                # V → tonic motion. F#→Bm is a minor authentic cadence;
+                # F#→B is a major authentic cadence; the chord-after-
+                # the-V information alone doesn't distinguish "the piece
+                # is in B" from "the piece is in B major vs B minor."
+                # Let the rest of the ensemble vote on mode.
+                cadence_counts[tonic_pc * 2] += 1  # Ionian slot
+                cadence_counts[tonic_pc * 2 + 1] += 1  # Aeolian slot
+
+        max_count = max(cadence_counts)
+        if max_count == 0:
+            # No cadences detected — return empty ranked list. Cadential
+            # has nothing to say about non-cadential progressions.
+            return KeyDetectionVerdict(
+                name=self.name,
+                ranked=[],
+                meta={"reason": "no_cadences_detected"},
+            )
+
+        ranked: List[Tuple[KeyInfo, float]] = []
+
+        for tonic_pc, tonic_name in enumerate(PITCH_CLASSES):
+            for slot_offset, mode_label in enumerate(("Ionian", "Aeolian")):
+                count = cadence_counts[tonic_pc * 2 + slot_offset]
+                normalized = count / max_count
+
+                key_is_minor = mode_label == "Aeolian"
+                key_str = f"{tonic_name} {'major' if not key_is_minor else 'minor'}"
+                key_info = KeyInfo(
+                    tonic=tonic_name,
+                    mode=mode_label,
+                    key_signature=key_str,
+                    confidence=round(normalized, 4),
+                )
+                ranked.append((key_info, normalized))
+
+        ranked.sort(key=lambda pair: pair[1], reverse=True)
+
+        return KeyDetectionVerdict(
+            name=self.name,
+            ranked=ranked,
+            meta={"max_cadence_count": max_count},
+        )

--- a/src/harmonic_analysis/audio/_key_approaches/template_correlation.py
+++ b/src/harmonic_analysis/audio/_key_approaches/template_correlation.py
@@ -1,0 +1,139 @@
+"""Krumhansl-Schmuckler template correlation as a KeyDetectionApproach.
+
+Direct port of ``find_best_key`` from ``_key_estimation.py``. The behavior
+must be bit-identical — AC-02 asserts that ``key_detection="ks_only"``
+produces the same KeyInfo (to 4 decimal places) as the pre-ensemble code
+path. Don't get clever with the math here. The thin wrapper in
+``_key_estimation.py`` calls this class's ``detect()`` and pulls out the
+top-1; if anything drifts, both that wrapper and AC-02 will tell us.
+
+The K-S profiles only know "major" and "minor" — i.e. Ionian and Aeolian.
+That's the whole point of ensembling: this approach can't tell relative
+pairs apart, so we let the others vote.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+from .._key_ensemble import (
+    KeyDetectionApproach,
+    KeyDetectionContext,
+    KeyDetectionVerdict,
+)
+from .._profiles import KS_PROFILES, PITCH_CLASSES
+from .._types import KeyInfo
+
+# Same map as _key_estimation.py uses. Output uses Ionian/Aeolian for
+# round-trip compatibility with the toolkit.
+_MODE_MAP: Dict[str, str] = {"major": "Ionian", "minor": "Aeolian"}
+
+
+class TemplateCorrelationApproach(KeyDetectionApproach):
+    """Pure K-S correlation, packaged as a protocol-conformant approach.
+
+    Computes Pearson correlation between the chroma vector and each of
+    the 24 rolled K-S profiles. Returns all 24 candidates ranked by
+    score — downstream synthesis decides how many actually matter.
+    Returning the full ranking (not just top-K) lets the synthesizer
+    accumulate per-approach evidence across all candidates instead of
+    losing tail signal.
+    """
+
+    name: str = "template_correlation"
+
+    def detect(self, ctx: KeyDetectionContext) -> KeyDetectionVerdict:
+        """Score all 24 keys via K-S correlation.
+
+        Args:
+            ctx: KeyDetectionContext. Only ``chroma_1d`` is consulted.
+
+        Returns:
+            KeyDetectionVerdict with all 24 (KeyInfo, score) pairs sorted
+            highest-score-first. Confidence in each KeyInfo is the per-key
+            raw correlation mapped to [0,1] — same ``round(c, 4)``
+            quantization as the original to preserve bit-identity.
+        """
+        chroma_vector = np.asarray(ctx.chroma_1d, dtype=float)
+
+        # Zero-energy guard — without this, np.corrcoef returns NaN against
+        # any constant input and downstream confidence math goes sideways.
+        # Match the original's behavior exactly.
+        if np.linalg.norm(chroma_vector) < 1e-6:
+            na_key = KeyInfo(
+                tonic="N/A",
+                mode="N/A",
+                key_signature="N/A",
+                confidence=0.0,
+            )
+            # Single N/A entry. Synthesizer treats this as "no signal" but
+            # a non-empty ranked list still satisfies AC-03's contract.
+            return KeyDetectionVerdict(
+                name=self.name,
+                ranked=[(na_key, 0.0)],
+                meta={"zero_energy": True},
+            )
+
+        # Compute all 24 correlations in the same order as the original.
+        # This ordering is load-bearing for tie-breaking — the original
+        # ``max(correlations, key=...)`` picks the first key encountered
+        # on a tie, which is dict-insertion order: tonic-major-then-minor
+        # for each pitch class C through B.
+        correlations: Dict[str, float] = {}
+        candidate_keys: Dict[str, KeyInfo] = {}
+
+        for tonic_pc, tonic_name in enumerate(PITCH_CLASSES):
+            for mode_name, profile_data in KS_PROFILES.items():
+                profile = np.roll(np.asarray(profile_data, dtype=float), tonic_pc)
+                corr = float(np.corrcoef(chroma_vector, profile)[0, 1])
+                key_str = f"{tonic_name} {mode_name}"
+                correlations[key_str] = corr
+
+                # Per-key confidence — same Pearson-to-[0,1] mapping the
+                # original applied to the winner. Each candidate's
+                # KeyInfo carries its own confidence value, which is what
+                # appears in the diagnostic panel.
+                if np.isnan(corr):
+                    confidence = 0.0
+                else:
+                    confidence = (corr + 1.0) / 2.0
+                candidate_keys[key_str] = KeyInfo(
+                    tonic=tonic_name,
+                    mode=_MODE_MAP.get(mode_name, mode_name),
+                    key_signature=key_str,
+                    confidence=round(confidence, 4),
+                )
+
+        # Build the ranked list. We sort by the RAW correlation (not the
+        # rounded confidence) so ties come out in the same order as the
+        # original ``max(correlations, key=...)`` — the rounding to 4
+        # decimal places would otherwise create false ties between keys
+        # whose correlations differ in the 5th decimal. Bit-identity is
+        # the AC-02 contract; this is how we keep it.
+        #
+        # The score handed to the synthesizer is the rounded confidence
+        # (in [0,1]) because raw correlations can be negative and the
+        # synthesizer's weighted-sum logic doesn't want to subtract from
+        # other approaches' positive votes.
+        decorated: List[Tuple[float, str, KeyInfo]] = []
+        for key_str, corr in correlations.items():
+            key_info = candidate_keys[key_str]
+            # NaN correlations sort to the bottom — they're zero-confidence.
+            sort_corr = corr if not np.isnan(corr) else float("-inf")
+            decorated.append((sort_corr, key_str, key_info))
+
+        # Stable sort on raw correlation, descending. Python's sort is
+        # stable, so the dict-insertion order breaks ties — matches the
+        # original ``max()`` semantics exactly.
+        decorated.sort(key=lambda x: x[0], reverse=True)
+        ranked: List[Tuple[KeyInfo, float]] = [
+            (ki, ki.confidence) for _, _, ki in decorated
+        ]
+
+        return KeyDetectionVerdict(
+            name=self.name,
+            ranked=ranked,
+            meta={"raw_correlations": correlations},
+        )

--- a/src/harmonic_analysis/audio/_key_ensemble.py
+++ b/src/harmonic_analysis/audio/_key_ensemble.py
@@ -1,0 +1,376 @@
+"""Pluggable key-detection ensemble: protocol, context, verdict, synthesizer.
+
+The single-algorithm Krumhansl-Schmuckler estimator can't tell relative pairs
+apart (D Ionian vs B Aeolian have identical pitch-class sets). That's a
+fundamental limitation of correlating against pitch-class profiles. The fix
+isn't a smarter K-S — it's adding orthogonal evidence (boundary chords, bass
+dominance, cadential motion) and letting them vote.
+
+This module defines the contract every approach implements (the
+``KeyDetectionApproach`` protocol), the data carrier that flows from caller
+to approaches (``KeyDetectionContext``), the per-approach output
+(``KeyDetectionVerdict``), and the weighted-sum aggregator
+(``KeyEnsembleSynthesizer``) that turns N verdicts into one ``SynthesisResult``.
+
+Implementations live in ``_key_approaches/``. The orchestration (which
+approaches run, which weights apply, when chord events are available) is in
+``integrations/audio_adapter.py``'s ``from_audio()`` — the ensemble doesn't
+know how to extract chroma, and chroma extraction doesn't know about the
+ensemble. Keeping that separation lets each layer evolve independently.
+
+A note on KeyInfo: it lives in ``_types.py`` and is frozen. Adding fields
+to it would break tests locked by audio_score_alignment-01. The new
+ensemble result types belong here, not over there.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Protocol, Tuple, Union
+
+import numpy as np
+
+from ._types import KeyInfo
+
+# Default weights for each approach. Conversation-derived starting points.
+# 1.0 / 0.8 / 0.6 / 0.7 / 1.2 / variable — these came from intuition, not
+# data. Real-world performance may force tuning. Iteration_02 owns the
+# ``pattern_engine`` and ``hmm`` slots; populated here so the table is
+# complete at import time and presets can reference all five.
+DEFAULT_WEIGHTS: Dict[str, float] = {
+    "template_correlation": 1.0,
+    "boundary_chords": 0.8,
+    "bass_dominance": 0.6,
+    "cadential": 0.7,
+    "pattern_engine": 0.9,
+    "hmm": 0.5,
+}
+
+# Approach name groupings keyed by preset string. The "default" set is the
+# four iteration_01 defaults. "ks_only" mirrors the pre-ensemble code path
+# for backward compat. "full" turns everything on, but in iteration_01 the
+# opt-ins haven't shipped yet — the resolver guards against missing
+# implementations elsewhere; here we just enumerate names.
+_PRESET_APPROACHES: Dict[str, List[str]] = {
+    "default": [
+        "template_correlation",
+        "boundary_chords",
+        "bass_dominance",
+        "cadential",
+    ],
+    "ks_only": ["template_correlation"],
+    "full": [
+        "template_correlation",
+        "boundary_chords",
+        "bass_dominance",
+        "cadential",
+        "pattern_engine",
+        "hmm",
+    ],
+}
+
+
+@dataclass(frozen=True)
+class KeyDetectionContext:
+    """Pre-computed inputs handed to every approach.
+
+    Optional fields let lightweight approaches (template_correlation only
+    needs chroma) ignore expensive inputs they don't use. The two-stage
+    pipeline puts chord_events behind None on stage 1 — when only the K-S
+    pass has run, the chord-event-dependent approaches will degrade
+    gracefully rather than blow up.
+
+    Attributes:
+        chroma_1d: Time-averaged 12-bin chroma vector. Required.
+        bass_chroma_1d: Optional 12-bin bass-register chroma. None means
+            the caller didn't extract it.
+        chord_events: Optional list of ChordEvent (typed loosely as object
+            to avoid the import dance — adapter passes the real ones).
+            None when running before chord estimation.
+        hmm_segments: Optional HMM segmentation output. iteration_02 only.
+        audio_path: Optional path to the source audio. Some opt-in
+            approaches re-extract chroma per segment; defaults rarely care.
+    """
+
+    chroma_1d: np.ndarray
+    bass_chroma_1d: Optional[np.ndarray] = None
+    chord_events: Optional[List[object]] = None
+    hmm_segments: Optional[List[object]] = None
+    audio_path: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class KeyDetectionVerdict:
+    """Output of one approach: ranked candidates with a name tag.
+
+    The ranked list preserves order naturally and matches the diagnostic
+    panel's "top_3" display. A dict-of-scores would force a re-sort at
+    every consumer.
+
+    Attributes:
+        name: Approach identifier (e.g. "template_correlation"). Must
+            match a key in DEFAULT_WEIGHTS for the synthesizer to
+            apply weight correctly.
+        ranked: List of (KeyInfo, score) pairs, sorted highest-score-first.
+            Empty list signals "no opinion" (e.g. cadential approach with
+            no V-I cadences in the chord events).
+        meta: Optional per-approach diagnostic data. Surfaced in the
+            details panel when show_analysis_details=True.
+    """
+
+    name: str
+    ranked: List[Tuple[KeyInfo, float]]
+    meta: Optional[Dict[str, object]] = None
+
+
+@dataclass(frozen=True)
+class SynthesisResult:
+    """Output of the ensemble synthesizer.
+
+    Attributes:
+        method: Synthesis method tag. iteration_01 only ships
+            "weighted_sum"; future methods (median, max, etc.) would
+            tag themselves here.
+        winner: KeyInfo with the highest weighted-sum total.
+        runner_up: KeyInfo in second place. None when only one candidate
+            received any score (rare — every approach scores 24 keys).
+        margin: ``winner_total - runner_up_total``. Confidence proxy for
+            "how much did the ensemble agree." Zero when there's a tie.
+        key_score_table: All candidates sorted by total weighted score.
+            Useful for the diagnostic panel and for debugging weight
+            tuning.
+        per_approach: List of (approach_name, weight) actually used in
+            the synthesis. Reflects what was wired up at runtime, not
+            what's in the static DEFAULT_WEIGHTS table.
+    """
+
+    method: str
+    winner: KeyInfo
+    runner_up: Optional[KeyInfo]
+    margin: float
+    key_score_table: Dict[str, float]
+    per_approach: List[Tuple[str, float]] = field(default_factory=list)
+
+
+class KeyDetectionApproach(Protocol):
+    """Contract every key-detection approach must satisfy.
+
+    Each implementation lives in ``_key_approaches/``. The protocol is
+    structural — no inheritance required, just a class with a ``name``
+    attribute and a ``detect`` method. This keeps tests clean (mock
+    objects with the right shape work) and avoids coupling approaches
+    to a base class.
+
+    A note on the empty-input contract: every approach must return a
+    valid ``KeyDetectionVerdict`` (potentially with an empty ranked list
+    or uniform low scores) when its inputs are missing. The two-stage
+    pipeline runs some approaches in stage 1 with chord_events=None, and
+    we'd rather get a no-op verdict than a crash. Crashes here would
+    take down the whole ensemble.
+    """
+
+    name: str
+
+    def detect(self, ctx: KeyDetectionContext) -> KeyDetectionVerdict:
+        """Score key candidates given the context. Must not raise on
+        missing optional context fields — return a low-confidence or
+        empty verdict instead.
+        """
+        ...
+
+
+class KeyEnsembleSynthesizer:
+    """Weighted-sum synthesizer over per-approach verdicts.
+
+    Pure data transformation. No I/O, no chroma extraction — give it
+    verdicts plus weights, get back a winner. Testable in isolation with
+    constructed mock verdicts (see tests/audio/test_key_ensemble.py).
+
+    Method:
+        For each (KeyInfo, score) tuple in each approach's ranked list,
+        add ``score * weights[approach_name]`` to that key's running
+        total. After all verdicts are processed, the key with the
+        highest total wins. Margin is ``winner_total - runner_up_total``.
+
+    Tie-breaking:
+        When two keys score identically, the first one encountered in
+        the iteration order wins. Pythonic dict ordering (insertion
+        order) makes this deterministic per run, even though the actual
+        winner depends on which approach voted first. This is a known
+        wart we accept for iteration_01 — explicit tie-break rules
+        (e.g. "prefer minor on equal score") could be added later.
+    """
+
+    method_name: str = "weighted_sum"
+
+    def synthesize(
+        self,
+        verdicts: List[KeyDetectionVerdict],
+        weights: Optional[Dict[str, float]] = None,
+    ) -> SynthesisResult:
+        """Combine verdicts into a single SynthesisResult.
+
+        Args:
+            verdicts: Per-approach verdicts. Empty list raises ValueError —
+                synthesis with nothing to synthesize is a programming
+                error upstream, not a graceful-degradation case.
+            weights: Override weights. None = use DEFAULT_WEIGHTS.
+                Approaches with no weight entry default to 0.0 (their
+                votes don't count). This is intentional — surfacing an
+                unknown approach via a silent skip is safer than
+                guessing a default.
+
+        Returns:
+            SynthesisResult with winner, runner_up, margin, and the full
+            score table for diagnostic display.
+
+        Raises:
+            ValueError: If ``verdicts`` is empty.
+        """
+        if not verdicts:
+            raise ValueError(
+                "synthesize() requires at least one verdict — empty input "
+                "indicates an upstream wiring bug, not a recoverable state."
+            )
+
+        effective_weights = weights if weights is not None else DEFAULT_WEIGHTS
+
+        # Running totals keyed by the KeyInfo's key_signature string.
+        # We use string keys because KeyInfo is frozen but contains a
+        # frozenset (diatonic_pitch_classes) — equality works fine, but
+        # using the string key keeps the score table directly serializable
+        # for the diagnostic panel.
+        score_table: Dict[str, float] = {}
+        # Map key_signature back to the canonical KeyInfo for the winner
+        # lookup. Multiple approaches may produce slightly different
+        # KeyInfo instances (different confidence values per approach);
+        # we keep the first one we see.
+        key_lookup: Dict[str, KeyInfo] = {}
+
+        per_approach: List[Tuple[str, float]] = []
+
+        for verdict in verdicts:
+            weight = effective_weights.get(verdict.name, 0.0)
+            per_approach.append((verdict.name, weight))
+
+            # Skip the approach entirely when its weight is zero —
+            # avoids polluting the score table with zero contributions
+            # and matches the user's mental model of "weight 0 = off."
+            if weight == 0.0:
+                continue
+
+            for key_info, score in verdict.ranked:
+                sig = key_info.key_signature
+                score_table[sig] = score_table.get(sig, 0.0) + score * weight
+                if sig not in key_lookup:
+                    key_lookup[sig] = key_info
+
+        if not score_table:
+            # All approaches had weight 0 or empty ranked lists. Best we can
+            # do: return the first verdict's first ranked item if any, else
+            # an N/A sentinel. Either way the caller has no useful signal.
+            for v in verdicts:
+                if v.ranked:
+                    fallback_key, _ = v.ranked[0]
+                    return SynthesisResult(
+                        method=self.method_name,
+                        winner=fallback_key,
+                        runner_up=None,
+                        margin=0.0,
+                        key_score_table={},
+                        per_approach=per_approach,
+                    )
+            # No ranked entries anywhere — synthesize an N/A sentinel.
+            na_key = KeyInfo(
+                tonic="N/A",
+                mode="N/A",
+                key_signature="N/A",
+                confidence=0.0,
+            )
+            return SynthesisResult(
+                method=self.method_name,
+                winner=na_key,
+                runner_up=None,
+                margin=0.0,
+                key_score_table={},
+                per_approach=per_approach,
+            )
+
+        # Sort by total score descending. Ties broken by dict insertion
+        # order (whichever approach voted first wins) — see class docstring
+        # for the ugly truth.
+        ranked_keys = sorted(score_table.items(), key=lambda kv: kv[1], reverse=True)
+
+        winner_sig, winner_total = ranked_keys[0]
+        winner = key_lookup[winner_sig]
+
+        runner_up: Optional[KeyInfo] = None
+        margin = 0.0
+        if len(ranked_keys) > 1:
+            runner_up_sig, runner_up_total = ranked_keys[1]
+            runner_up = key_lookup[runner_up_sig]
+            margin = winner_total - runner_up_total
+
+        return SynthesisResult(
+            method=self.method_name,
+            winner=winner,
+            runner_up=runner_up,
+            margin=margin,
+            key_score_table=dict(ranked_keys),
+            per_approach=per_approach,
+        )
+
+
+def resolve_preset(
+    spec: Union[str, List[str], Dict[str, float]]
+) -> Tuple[List[str], Dict[str, float]]:
+    """Translate a key_detection spec into (approach_names, weights).
+
+    Three input shapes:
+        * str: preset name from _PRESET_APPROACHES ("default" | "ks_only"
+          | "full"). Returns the preset's approach list with default
+          weights.
+        * list[str]: explicit list of approach names. Uses default weights.
+        * dict[str, float]: approach-name → weight mapping. Both the names
+          and weights come from the dict; missing approaches are simply
+          excluded.
+
+    Args:
+        spec: Preset name, name list, or weight dict.
+
+    Returns:
+        Tuple of (approach_names, weights_dict).
+
+    Raises:
+        ValueError: For unknown preset names or empty lists.
+    """
+    if isinstance(spec, str):
+        if spec not in _PRESET_APPROACHES:
+            valid = ", ".join(sorted(_PRESET_APPROACHES))
+            raise ValueError(
+                f"Unknown key_detection preset {spec!r}. " f"Valid presets: {valid}."
+            )
+        names = list(_PRESET_APPROACHES[spec])
+        weights = {name: DEFAULT_WEIGHTS.get(name, 0.0) for name in names}
+        return names, weights
+
+    if isinstance(spec, dict):
+        if not spec:
+            raise ValueError("key_detection dict is empty — nothing to run.")
+        names = list(spec.keys())
+        # User-supplied weights win; we don't blend with defaults because
+        # that would surprise people who pass a dict expecting it to be
+        # the complete spec.
+        weights = {k: float(v) for k, v in spec.items()}
+        return names, weights
+
+    if isinstance(spec, list):
+        if not spec:
+            raise ValueError("key_detection list is empty — nothing to run.")
+        names = list(spec)
+        weights = {name: DEFAULT_WEIGHTS.get(name, 0.0) for name in names}
+        return names, weights
+
+    raise ValueError(
+        f"key_detection must be str, list, or dict; got {type(spec).__name__}."
+    )

--- a/src/harmonic_analysis/audio/_key_estimation.py
+++ b/src/harmonic_analysis/audio/_key_estimation.py
@@ -1,82 +1,61 @@
-"""Krumhansl-Schmuckler key estimation from a 12-bin chroma vector.
+"""Krumhansl-Schmuckler key estimation (thin backward-compat wrapper).
 
-Direct port of the toolkit's ``find_best_key`` (utils.py:45–81) with two
-deliberate changes:
+The K-S logic moved to ``_key_approaches/template_correlation.py`` as
+part of the audio_score_alignment-02 ensemble. This file is now a thin
+shim — it preserves the ``find_best_key`` import path for any caller
+(internal or external) that still expects to call into this module.
 
-1. Returns a ``KeyInfo`` dataclass instead of a dict — the rest of the audio
-   pipeline expects a typed object.
-2. No external theory-library dependency. The toolkit's reference
-   implementation didn't actually call out to one in this function, but
-   downstream callers did via the dict it returned. Now everything stays
-   inside the audio subpackage.
+Migration notes:
+    Old code:
+        from harmonic_analysis.audio._key_estimation import find_best_key
+        result = find_best_key(chroma_vector)
 
-K-S profiles only know "major" and "minor" — i.e. Ionian and Aeolian. The
-mode_map below preserves the toolkit's labels (so callers see "Ionian", not
-"major"). Modal scales beyond Ionian/Aeolian are a WU3 problem.
+    New code (with ensemble):
+        # Backward-compat — same behavior as before
+        result = find_best_key(chroma_vector)
+
+        # Or via the adapter for the full ensemble:
+        from harmonic_analysis import analyze_audio_async
+        result = await analyze_audio_async(filepath, key_detection="default")
+        # ...where key_detection="ks_only" recovers the old behavior.
+
+The wrapper is deliberately a one-liner. AC-02 of the ensemble scope
+asserts bit-identical behavior between this function and the
+pre-ensemble code path, to 4 decimal places. Any cleverness here
+(rounding, normalization, mode mapping) would break that assertion.
+The ``TemplateCorrelationApproach.detect()`` does the K-S math; we
+just unpack its top-1 KeyInfo and return it.
 """
 
 from __future__ import annotations
 
-from typing import Dict
-
 import numpy as np
 
-from ._profiles import KS_PROFILES, PITCH_CLASSES
+from ._key_approaches.template_correlation import TemplateCorrelationApproach
+from ._key_ensemble import KeyDetectionContext
 from ._types import KeyInfo
-
-# Toolkit labels major/minor as Ionian/Aeolian on output. Preserved verbatim
-# so the rest of the pipeline doesn't have to translate.
-_MODE_MAP: Dict[str, str] = {"major": "Ionian", "minor": "Aeolian"}
 
 
 def find_best_key(chroma_vector: np.ndarray) -> KeyInfo:
     """Estimate the best-fitting key for a 12-bin chroma vector.
+
+    Thin wrapper around ``TemplateCorrelationApproach.detect()``. The
+    K-S correlation logic, zero-energy guard, and confidence rounding
+    all live in the approach class — this function just delegates.
 
     Args:
         chroma_vector: 12-element float array of pitch-class energies.
 
     Returns:
         ``KeyInfo`` with tonic, mode (Ionian/Aeolian), full key_signature
-        string ("C major"-style — note: still uses the K-S "major"/"minor"
-        labels for round-trip compatibility with the toolkit), and a
-        confidence in [0.0, 1.0]. Zero-energy input returns an N/A sentinel.
+        string ("C major"-style), and a confidence in [0.0, 1.0].
+        Zero-energy input returns the N/A sentinel.
     """
-    # Zero-energy guard. Without this, np.corrcoef returns NaN against any
-    # constant input and downstream confidence math goes sideways.
-    if np.linalg.norm(chroma_vector) < 1e-6:
-        return KeyInfo(
-            tonic="N/A",
-            mode="N/A",
-            key_signature="N/A",
-            confidence=0.0,
-        )
-
-    correlations: Dict[str, float] = {}
-    for tonic_pc, tonic_name in enumerate(PITCH_CLASSES):
-        for mode_name, profile_data in KS_PROFILES.items():
-            # Roll the K-S profile so position 0 sits on this candidate tonic.
-            profile = np.roll(np.asarray(profile_data, dtype=float), tonic_pc)
-            corr = float(np.corrcoef(chroma_vector, profile)[0, 1])
-            correlations[f"{tonic_name} {mode_name}"] = corr
-
-    # max() with key= over a dict iterates keys; pick the one with the
-    # highest correlation. Ties broken by dict insertion order — fine for
-    # K-S, the 24-key search rarely has exact ties on real chroma.
-    best_key = max(correlations, key=lambda k: correlations[k])
-    raw_corr = correlations[best_key]
-
-    # Pearson correlation lives in [-1, 1]; map to [0, 1] for an interpretable
-    # "confidence." Second NaN guard catches the edge case where chroma had
-    # nonzero norm but matched zero-variance somehow (constant chroma).
-    if np.isnan(raw_corr):
-        confidence = 0.0
-    else:
-        confidence = (raw_corr + 1.0) / 2.0
-
-    tonic_name, mode_name = best_key.split()
-    return KeyInfo(
-        tonic=tonic_name,
-        mode=_MODE_MAP.get(mode_name, mode_name),
-        key_signature=best_key,
-        confidence=round(confidence, 4),
+    # One-liner delegation — no intermediate logic. AC-02 demands
+    # bit-identity with the pre-ensemble path; this wrapper is the
+    # contract surface that backward-compat callers see.
+    return (
+        TemplateCorrelationApproach()
+        .detect(KeyDetectionContext(chroma_1d=chroma_vector))
+        .ranked[0][0]
     )

--- a/src/harmonic_analysis/integrations/audio_adapter.py
+++ b/src/harmonic_analysis/integrations/audio_adapter.py
@@ -27,9 +27,19 @@ import asyncio
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 logger = logging.getLogger(__name__)
+
+# Default ensemble preset — used when callers don't pass key_detection.
+# "default" enables the four iteration_01 approaches; ks_only mirrors the
+# pre-ensemble code path for backward compat.
+_DEFAULT_KEY_DETECTION = "default"
+
+# Type alias for the key_detection parameter shape. Three input shapes:
+# preset string ("default" | "ks_only" | "full"), explicit list of approach
+# names, or dict mapping approach name → weight.
+KeyDetectionSpec = Union[str, List[str], Dict[str, float]]
 
 # Rubato presets: (window_size_s, hop_size_s, median_kernel).
 # Named after the musical term because that's literally what this controls —
@@ -153,6 +163,10 @@ class AudioAnalysisResult:
     segment_start: float
     segment_end: float
     chords: list[ChordEvent] = field(default_factory=list)
+    # Diagnostic-panel payload populated only when callers ask for it. None
+    # by default to keep production payloads light. Schema documented in
+    # docs/reference/audio-api.md and at AC-05.
+    key_analysis_details: Optional[Dict[str, Any]] = None
 
     @property
     def key_hint(self) -> str:
@@ -245,6 +259,9 @@ class AudioAdapter:
         bass_bonus: float = 0.3,
         rubato: Union[str, float] = "moderate",
         min_chroma_norm: float = 0.05,
+        key_detection: KeyDetectionSpec = _DEFAULT_KEY_DETECTION,
+        show_analysis_details: bool = False,
+        key_ensemble_weights: Optional[Dict[str, float]] = None,
     ) -> None:
         """Initialize the adapter.
 
@@ -279,11 +296,28 @@ class AudioAdapter:
             min_chroma_norm: L2 norm threshold below which a chroma window
                 is treated as silence and skipped. Prevents hallucinated
                 chords during dead air. Default 0.05.
+            key_detection: Ensemble preset, list of approach names, or
+                dict of approach-name → weight. Defaults to ``"default"``
+                which enables ``template_correlation``, ``boundary_chords``,
+                ``bass_dominance``, and ``cadential``. ``"ks_only"`` runs
+                only the K-S template correlation (matches pre-ensemble
+                behavior). ``"full"`` includes the iteration_02 opt-ins
+                ``pattern_engine`` and ``hmm`` (which fall back to no-op
+                in iteration_01).
+            show_analysis_details: When ``True``, populates
+                ``AudioAnalysisResult.key_analysis_details`` with a
+                per-approach breakdown for debugging. Off by default to
+                keep payloads light for production callers.
+            key_ensemble_weights: Optional override for the per-approach
+                weights. Replaces the default weights for any approach
+                listed; unlisted approaches retain their default weight.
 
         Raises:
             AudioImportError: If ``librosa`` or ``soundfile`` cannot be
                 imported. Message contains ``"audio"`` and
                 ``"pip install"`` for grep-friendly install guidance.
+            ValueError: If ``key_detection`` is an unknown preset string,
+                an empty list, or an empty dict.
         """
         # Lazy import — keeps `import harmonic_analysis` lean. We don't
         # store the modules on self because _io.py imports them directly;
@@ -321,6 +355,21 @@ class AudioAdapter:
         self._bass_bonus = bass_bonus
         self._median_kernel = rubato_kernel
         self._min_chroma_norm = min_chroma_norm
+
+        # Resolve key_detection up front. resolve_preset() validates the
+        # spec and raises ValueError for bad input — we want the failure
+        # at construction time, not deep inside from_audio().
+        from harmonic_analysis.audio._key_ensemble import resolve_preset
+
+        approach_names, resolved_weights = resolve_preset(key_detection)
+        # Apply user weight overrides on top of the resolved defaults.
+        if key_ensemble_weights:
+            for k, v in key_ensemble_weights.items():
+                resolved_weights[k] = float(v)
+        self._key_detection_spec: KeyDetectionSpec = key_detection
+        self._approach_names: List[str] = approach_names
+        self._approach_weights: Dict[str, float] = resolved_weights
+        self._show_analysis_details = show_analysis_details
 
         if not quiet and not self.ffmpeg_available:
             # Single WARNING — informational, not a fail. WAV still works.
@@ -376,13 +425,26 @@ class AudioAdapter:
             extract_global_chroma,
             extract_local_chroma,
         )
-        from harmonic_analysis.audio._key_estimation import find_best_key
+        from harmonic_analysis.audio._key_approaches import DEFAULT_APPROACH_REGISTRY
+        from harmonic_analysis.audio._key_approaches.template_correlation import (
+            TemplateCorrelationApproach,
+        )
+        from harmonic_analysis.audio._key_ensemble import (
+            KeyDetectionContext,
+            KeyEnsembleSynthesizer,
+        )
         from harmonic_analysis.audio._region import classify_region_type
 
-        # Step 1 — global chroma + global key. Already 1D (12,) per the
-        # _io.py contract; pass directly to find_best_key.
+        # Step 1 — global chroma + STAGE 1 key (template_correlation only).
+        # The K-S result feeds chord estimation's tonal_bias. Even if the
+        # ensemble eventually picks a different key, tonal_bias only
+        # affects diatonic-chord weighting and relative pairs share the
+        # same diatonic set — so stage-1 K-S is good enough here.
         global_chroma = extract_global_chroma(filepath)
-        global_key = find_best_key(global_chroma)
+        ks_verdict = TemplateCorrelationApproach().detect(
+            KeyDetectionContext(chroma_1d=global_chroma)
+        )
+        ks_key = ks_verdict.ranked[0][0]
 
         # Step 2 — resolve segment bounds. Default: whole file. We need
         # to know file duration up front to fill in segment_end when no
@@ -408,72 +470,176 @@ class AudioAdapter:
         local_chroma = extract_local_chroma(
             filepath, start_time=resolved_start, end_time=resolved_end
         )
-
-        # Step 4 — local key. find_best_key expects 1D 12-bin;
-        # detect_cadences expects 2D (12,T) raw — see WU2 prepare doc.
-        # (12,T) → (12,) required by find_best_key; averaging done here,
-        # not in the estimator.
         local_chroma_1d = local_chroma.mean(axis=1)
-        local_key = find_best_key(local_chroma_1d)
 
-        # Step 5 — cadences. Pass the full 2D matrix; detect_cadences
-        # does its own .mean(axis=1) internally.
-        cadences = detect_cadences(local_chroma, local_key)
+        # Step 4 — STAGE 2: chord estimation, biased by the K-S key.
+        # Always extract bass chroma when we'll need it for the ensemble
+        # (or when use_bass_chroma is on). We compute it once and reuse
+        # for both chord-estimation bonus and bass_dominance approach.
+        bass_chroma = None
+        bass_chroma_1d = None
+        need_bass_for_ensemble = "bass_dominance" in self._approach_names
+        if self._use_bass_chroma or need_bass_for_ensemble:
+            from harmonic_analysis.audio._io import extract_local_bass_chroma
 
-        # Step 6 — region classification. Threshold tuning lives in
-        # _region.py and is not our concern here.
-        region = classify_region_type(
-            global_key=global_key,
-            local_key=local_key,
-            local_key_confidence=local_key.confidence,
-            local_cadence=cadences,
-        )
+            bass_chroma = extract_local_bass_chroma(
+                filepath, start_time=resolved_start, end_time=resolved_end
+            )
+            bass_chroma_1d = bass_chroma.mean(axis=1)
 
-        # Step 7 — chord estimation. Uses the 2D local chroma and global key.
-        # Gated by _include_chords — skip the (cheap) computation when the
-        # caller explicitly opted out.
         chords: list[ChordEvent] = []
         if self._include_chords:
             from harmonic_analysis.audio._chord_estimation import (
                 estimate_chord_progression,
             )
 
-            # Bass-aware estimation: extract a parallel bass-register
-            # chroma and pass it to the estimator. Disambiguates relative
-            # pairs (Bm vs D, Am vs C) when the bass note is the
-            # discriminating signal. Costs a second chroma pass over the
-            # audio — typically <100ms for songs under ~5 minutes.
-            bass_chroma = None
-            if self._use_bass_chroma:
-                from harmonic_analysis.audio._io import extract_local_bass_chroma
-
-                bass_chroma = extract_local_bass_chroma(
-                    filepath, start_time=resolved_start, end_time=resolved_end
-                )
-
             chords = estimate_chord_progression(
                 local_chroma,
-                global_key,
+                ks_key,  # tonal_bias driven by K-S — stage-1 result
                 sr=sr,
                 hop_length=512,
                 window_size_s=self._chord_window_size_s,
                 hop_size_s=self._chord_hop_size_s,
                 tonal_bias=self._tonal_bias,
-                bass_chroma_frames=bass_chroma,
+                bass_chroma_frames=bass_chroma if self._use_bass_chroma else None,
                 bass_bonus=self._bass_bonus,
                 min_chroma_norm=self._min_chroma_norm,
                 median_kernel=self._median_kernel,
             )
 
+        # Step 5 — STAGE 3: full ensemble. Run every enabled approach
+        # against a context that now includes chord events from stage 2.
+        ensemble_ctx = KeyDetectionContext(
+            chroma_1d=global_chroma,
+            bass_chroma_1d=bass_chroma_1d,
+            chord_events=list(chords) if chords else None,
+            audio_path=str(filepath),
+        )
+
+        verdicts = []
+        for name in self._approach_names:
+            cls = DEFAULT_APPROACH_REGISTRY.get(name)
+            if cls is None:
+                # Iteration_02 opt-ins (pattern_engine, hmm) aren't
+                # registered yet. Skip silently — including their names
+                # in "full" preset is forward-compat scaffolding.
+                continue
+            verdicts.append(cls().detect(ensemble_ctx))
+
+        # If only template_correlation ran (ks_only path), we're done —
+        # the synthesizer will return a SynthesisResult whose winner is
+        # the K-S key. No special-case needed.
+        synthesizer = KeyEnsembleSynthesizer()
+        synthesis_result = synthesizer.synthesize(
+            verdicts, weights=self._approach_weights
+        )
+        ensemble_key = synthesis_result.winner
+
+        # Step 6 — local key. With segments, the local chroma differs
+        # from the global; recompute via ensemble using the local chroma.
+        # When no segment is set, local == global by construction so we
+        # reuse the ensemble winner to avoid redundant work.
+        if segment is None:
+            local_key = ensemble_key
+            # Cadences and region still want their inputs; reuse local_chroma.
+        else:
+            # Run a smaller ensemble on the local chroma. We use
+            # template_correlation only here for performance — the
+            # boundary/bass/cadential signals are global concepts and
+            # don't need re-running per segment.
+            local_ks = TemplateCorrelationApproach().detect(
+                KeyDetectionContext(chroma_1d=local_chroma_1d)
+            )
+            local_key = local_ks.ranked[0][0]
+
+        # Step 7 — cadences and region classification. detect_cadences
+        # does its own .mean(axis=1) internally on the 2D matrix.
+        cadences = detect_cadences(local_chroma, local_key)
+        region = classify_region_type(
+            global_key=ensemble_key,
+            local_key=local_key,
+            local_key_confidence=local_key.confidence,
+            local_cadence=cadences,
+        )
+
+        # Step 8 — diagnostic panel (only when requested).
+        key_analysis_details: Optional[Dict[str, Any]] = None
+        if self._show_analysis_details:
+            key_analysis_details = self._build_analysis_details(
+                verdicts=verdicts, synthesis=synthesis_result
+            )
+
         return AudioAnalysisResult(
-            global_key=global_key,
+            global_key=ensemble_key,
             local_key=local_key,
             cadences=cadences,
             region=region,
             segment_start=resolved_start,
             segment_end=resolved_end,
             chords=chords,
+            key_analysis_details=key_analysis_details,
         )
+
+    def _build_analysis_details(
+        self,
+        *,
+        verdicts: list,
+        synthesis: object,
+    ) -> Dict[str, Any]:
+        """Construct the show_analysis_details payload.
+
+        Schema is locked by AC-05:
+            {
+                "approaches": [{"name", "weight", "top_3": [{...}]}, ...],
+                "synthesis": {
+                    "method", "winner": {...}, "runner_up": {...} | None,
+                    "margin", "key_score_table"
+                },
+                "modulations": None,  # iteration_02 owns the HMM segments
+            }
+
+        KeyInfo objects get manually serialized — the frozenset
+        ``diatonic_pitch_classes`` would explode any naive ``asdict``.
+        """
+
+        def _key_to_dict(ki: object) -> Dict[str, Any]:
+            return {
+                "tonic": getattr(ki, "tonic", None),
+                "mode": getattr(ki, "mode", None),
+                "key_signature": getattr(ki, "key_signature", None),
+                "confidence": getattr(ki, "confidence", None),
+            }
+
+        approaches_payload = []
+        for v in verdicts:
+            top_3 = [
+                {"key": _key_to_dict(k), "score": float(s)} for k, s in v.ranked[:3]
+            ]
+            approaches_payload.append(
+                {
+                    "name": v.name,
+                    "weight": float(self._approach_weights.get(v.name, 0.0)),
+                    "top_3": top_3,
+                }
+            )
+
+        synth_payload = {
+            "method": getattr(synthesis, "method", "weighted_sum"),
+            "winner": _key_to_dict(getattr(synthesis, "winner", None)),
+            "runner_up": (
+                _key_to_dict(getattr(synthesis, "runner_up"))
+                if getattr(synthesis, "runner_up", None) is not None
+                else None
+            ),
+            "margin": float(getattr(synthesis, "margin", 0.0)),
+            "key_score_table": dict(getattr(synthesis, "key_score_table", {})),
+        }
+
+        return {
+            "approaches": approaches_payload,
+            "synthesis": synth_payload,
+            "modulations": None,  # iteration_02
+        }
 
 
 def analyze_audio(
@@ -489,6 +655,9 @@ def analyze_audio(
     bass_bonus: float = 0.3,
     rubato: Union[str, float] = "moderate",
     min_chroma_norm: float = 0.05,
+    key_detection: KeyDetectionSpec = _DEFAULT_KEY_DETECTION,
+    show_analysis_details: bool = False,
+    key_ensemble_weights: Optional[Dict[str, float]] = None,
 ) -> AudioAnalysisResult:
     """Synchronous convenience wrapper around ``AudioAdapter.from_audio``.
 
@@ -531,6 +700,9 @@ def analyze_audio(
         bass_bonus=bass_bonus,
         rubato=rubato,
         min_chroma_norm=min_chroma_norm,
+        key_detection=key_detection,
+        show_analysis_details=show_analysis_details,
+        key_ensemble_weights=key_ensemble_weights,
     )
     return adapter.from_audio(filepath, segment=segment)
 
@@ -548,6 +720,9 @@ async def analyze_audio_async(
     bass_bonus: float = 0.3,
     rubato: Union[str, float] = "moderate",
     min_chroma_norm: float = 0.05,
+    key_detection: KeyDetectionSpec = _DEFAULT_KEY_DETECTION,
+    show_analysis_details: bool = False,
+    key_ensemble_weights: Optional[Dict[str, float]] = None,
 ) -> AudioAnalysisResult:
     """Async convenience wrapper. Offloads librosa work to a worker thread.
 
@@ -591,4 +766,7 @@ async def analyze_audio_async(
         bass_bonus=bass_bonus,
         rubato=rubato,
         min_chroma_norm=min_chroma_norm,
+        key_detection=key_detection,
+        show_analysis_details=show_analysis_details,
+        key_ensemble_weights=key_ensemble_weights,
     )

--- a/tests/audio/_key_approaches/__init__.py
+++ b/tests/audio/_key_approaches/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the four iteration_01 default key-detection approaches."""

--- a/tests/audio/_key_approaches/test_bass_dominance.py
+++ b/tests/audio/_key_approaches/test_bass_dominance.py
@@ -1,0 +1,85 @@
+"""Unit tests for the bass_dominance approach.
+
+AC-03 rows 4 (B-dominant bass → B winner) and 5 (no bass chroma →
+graceful empty verdict).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from harmonic_analysis.audio._key_approaches.bass_dominance import BassDominanceApproach
+from harmonic_analysis.audio._key_ensemble import KeyDetectionContext
+
+
+def _chroma_stub() -> np.ndarray:
+    return np.ones(12, dtype=float) / 12.0
+
+
+def _bass_chroma_dominated_by(pc: int) -> np.ndarray:
+    """Synthesize a bass chroma vector with strong dominance at pitch class ``pc``."""
+    bass = np.full(12, 0.05, dtype=float)
+    bass[pc] = 0.9
+    return bass
+
+
+def test_b_dominant_bass_wins_b_keys() -> None:
+    """Bass chroma peaked at B (pc 11) → top-ranked tonic should be B."""
+    bass = _bass_chroma_dominated_by(11)  # B is pitch class 11
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), bass_chroma_1d=bass)
+
+    verdict = BassDominanceApproach().detect(ctx)
+
+    assert verdict.name == "bass_dominance"
+    assert len(verdict.ranked) > 0
+    top_key, top_score = verdict.ranked[0]
+    assert top_key.tonic == "B"
+    assert top_score > 0.0
+
+
+def test_c_dominant_bass_wins_c_keys() -> None:
+    """Bass chroma peaked at C (pc 0) → top-ranked tonic should be C."""
+    bass = _bass_chroma_dominated_by(0)
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), bass_chroma_1d=bass)
+
+    verdict = BassDominanceApproach().detect(ctx)
+
+    top_key, _ = verdict.ranked[0]
+    assert top_key.tonic == "C"
+
+
+def test_none_bass_chroma_returns_empty_verdict() -> None:
+    """bass_chroma_1d=None (stage 1 path) → empty verdict, no crash."""
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), bass_chroma_1d=None)
+
+    verdict = BassDominanceApproach().detect(ctx)
+
+    assert verdict.ranked == []
+    assert verdict.meta is not None
+
+
+def test_zero_energy_bass_returns_empty_verdict() -> None:
+    """Bass chroma all zeros → can't normalize, return empty verdict."""
+    bass = np.zeros(12, dtype=float)
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), bass_chroma_1d=bass)
+
+    verdict = BassDominanceApproach().detect(ctx)
+
+    assert verdict.ranked == []
+
+
+def test_returns_24_ranked_entries_when_bass_present() -> None:
+    bass = _bass_chroma_dominated_by(7)  # G
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), bass_chroma_1d=bass)
+
+    verdict = BassDominanceApproach().detect(ctx)
+    assert len(verdict.ranked) == 24
+
+
+def test_bad_shape_bass_returns_empty_verdict() -> None:
+    """Wrong-shape bass vector should not crash — degrade to empty."""
+    bass = np.array([0.1, 0.2], dtype=float)  # too short
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), bass_chroma_1d=bass)
+
+    verdict = BassDominanceApproach().detect(ctx)
+    assert verdict.ranked == []

--- a/tests/audio/_key_approaches/test_boundary_chords.py
+++ b/tests/audio/_key_approaches/test_boundary_chords.py
@@ -1,0 +1,234 @@
+"""Unit tests for the boundary_chords approach.
+
+AC-03 row 2 (Bm boundaries → B Aeolian wins) and row 3 (empty events →
+graceful empty verdict). Plus a major-key sanity check (C-major
+boundaries → C Ionian wins).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from harmonic_analysis.audio._key_approaches.boundary_chords import (
+    BoundaryChordsApproach,
+)
+from harmonic_analysis.audio._key_ensemble import KeyDetectionContext
+
+
+@dataclass
+class _FakeChordEvent:
+    """Minimal chord-event stub. The approach only reads chord_label."""
+
+    chord_label: str
+    start_time: float = 0.0
+    end_time: float = 1.0
+    confidence: float = 0.9
+    is_diatonic: bool = True
+
+
+def _chroma_stub() -> np.ndarray:
+    """A 12-vector that's nonzero so contexts don't accidentally trip a
+    chroma-related code path. The approach doesn't actually consult it."""
+    return np.ones(12, dtype=float) / 12.0
+
+
+def test_bm_boundaries_score_b_aeolian_top() -> None:
+    """First and last chord = Bm → B Aeolian should win."""
+    events = [
+        _FakeChordEvent("Bm"),
+        _FakeChordEvent("D"),
+        _FakeChordEvent("A"),
+        _FakeChordEvent("G"),
+        _FakeChordEvent("Bm"),
+    ]
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
+
+    verdict = BoundaryChordsApproach().detect(ctx)
+
+    assert verdict.name == "boundary_chords"
+    assert len(verdict.ranked) > 0
+    top_key, top_score = verdict.ranked[0]
+    assert top_key.tonic == "B"
+    assert top_key.mode == "Aeolian"
+    assert top_score > 0.0
+
+
+def test_c_major_boundaries_score_c_ionian_top() -> None:
+    """V→I bookending in C major: opener and closer both C → C Ionian wins."""
+    events = [
+        _FakeChordEvent("C"),
+        _FakeChordEvent("F"),
+        _FakeChordEvent("G"),
+        _FakeChordEvent("C"),
+    ]
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
+
+    verdict = BoundaryChordsApproach().detect(ctx)
+
+    top_key, _ = verdict.ranked[0]
+    assert top_key.tonic == "C"
+    assert top_key.mode == "Ionian"
+
+
+def test_empty_chord_events_graceful_empty_verdict() -> None:
+    """Empty chord events → empty ranked list; no crash."""
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=[])
+
+    verdict = BoundaryChordsApproach().detect(ctx)
+
+    assert verdict.name == "boundary_chords"
+    assert verdict.ranked == []
+    assert verdict.meta is not None
+
+
+def test_none_chord_events_graceful_empty_verdict() -> None:
+    """chord_events=None (stage 1 of two-stage pipeline) → empty verdict."""
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=None)
+
+    verdict = BoundaryChordsApproach().detect(ctx)
+
+    assert verdict.ranked == []
+
+
+def test_dominant_match_scores_lower_than_tonic_match() -> None:
+    """V on the boundary should score lower than I on the boundary."""
+    # First and last = G (dominant of C major)
+    events_v = [_FakeChordEvent("G"), _FakeChordEvent("C"), _FakeChordEvent("G")]
+    # First and last = C (tonic of C major)
+    events_i = [_FakeChordEvent("C"), _FakeChordEvent("G"), _FakeChordEvent("C")]
+
+    chroma = _chroma_stub()
+    v_verdict = BoundaryChordsApproach().detect(
+        KeyDetectionContext(chroma_1d=chroma, chord_events=events_v)
+    )
+    i_verdict = BoundaryChordsApproach().detect(
+        KeyDetectionContext(chroma_1d=chroma, chord_events=events_i)
+    )
+
+    # Find C major's score in each
+    v_c_score = next(
+        s for k, s in v_verdict.ranked if k.tonic == "C" and k.mode == "Ionian"
+    )
+    i_c_score = next(
+        s for k, s in i_verdict.ranked if k.tonic == "C" and k.mode == "Ionian"
+    )
+    assert i_c_score > v_c_score
+
+
+def test_returns_24_ranked_entries() -> None:
+    """Every key in the 24-key universe gets a row."""
+    events = [_FakeChordEvent("Bm"), _FakeChordEvent("Bm")]
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
+
+    verdict = BoundaryChordsApproach().detect(ctx)
+
+    assert len(verdict.ranked) == 24
+
+
+# ---------------------------------------------------------------------------
+# iteration_01_a: filtering of garbage edge events. The chord estimator
+# emits events for silent lead-in / decay-tail with low confidence and/or
+# short duration — those are not real played chords. Without filtering
+# the approach would mis-identify the boundaries on real audio.
+# ---------------------------------------------------------------------------
+
+
+def test_filters_low_confidence_and_short_duration_boundary_events() -> None:
+    """Mixed sequence: leading low-conf garbage, valid Bm middle, trailing
+    short-duration garbage → boundaries should resolve to the valid Bm
+    chords, not the garbage. Mirrors the diagnostic-MP3 failure mode where
+    a "D conf 0.82" lead-in and "G dur 0.3s" trail were being treated as
+    real boundary signal."""
+    events = [
+        # Leading garbage: silent-lead-in K-S fallback artifact.
+        # Fails confidence threshold (0.82 < 0.85). Duration is fine.
+        _FakeChordEvent("D", start_time=0.00, end_time=0.75, confidence=0.82),
+        # Valid Bm — well-played, clearly above both thresholds.
+        _FakeChordEvent("Bm", start_time=1.00, end_time=2.75, confidence=0.94),
+        # Interior content (F#) — also qualifies, so to make the test
+        # robust about the *trailing-Bm boundary* claim we tuck the
+        # interior content between two Bm events. Mirrors the diagnostic
+        # MP3 where multiple Bm regions sandwich the V→i material.
+        _FakeChordEvent("F#", start_time=2.75, end_time=4.50, confidence=0.91),
+        _FakeChordEvent("Bm", start_time=4.50, end_time=6.50, confidence=0.97),
+        # Trailing garbage: trailing-decay tail.
+        # Confidence is fine (0.85), but duration fails (0.3s < 0.5s).
+        _FakeChordEvent("G", start_time=6.50, end_time=6.80, confidence=0.85),
+    ]
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
+
+    verdict = BoundaryChordsApproach().detect(ctx)
+
+    # Top key should be B-rooted. Both qualifying boundaries are Bm (a
+    # minor chord on B) so B Aeolian gets the full quality-match bonus
+    # at both ends — should beat B Ionian (wrong-quality match).
+    top_key, _ = verdict.ranked[0]
+    assert top_key.tonic == "B", (
+        f"Expected B (qualifying boundaries are both Bm), "
+        f"got {top_key.tonic} {top_key.mode}"
+    )
+    assert top_key.mode == "Aeolian", (
+        "Both Bm boundaries match Aeolian's minor tonic chord quality, "
+        f"so Aeolian should outrank Ionian; got mode={top_key.mode}"
+    )
+
+    # Sanity: the meta should reflect the qualifying boundaries (Bm),
+    # not the raw garbage events (D / G). If meta still says D/G, the
+    # diagnostic panel would invisibly hide the bug we just fixed.
+    assert verdict.meta is not None
+    assert verdict.meta["first_chord"] == "Bm"
+    assert verdict.meta["last_chord"] == "Bm"
+
+
+def test_filters_garbage_with_explicit_thresholds() -> None:
+    """Same garbage-vs-valid pattern but with explicit threshold args.
+    Proves the parameters are honored (not silently hardcoded)."""
+    events = [
+        # At default confidence threshold 0.85, this would be filtered;
+        # with min_confidence=0.80, it qualifies. We use this to verify
+        # the parameter wires through.
+        _FakeChordEvent("C", start_time=0.0, end_time=1.0, confidence=0.82),
+        _FakeChordEvent("G", start_time=1.0, end_time=2.0, confidence=0.93),
+        _FakeChordEvent("C", start_time=2.0, end_time=3.0, confidence=0.82),
+    ]
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
+
+    # Loose thresholds: all events qualify, both ends are C → C Ionian wins.
+    loose_verdict = BoundaryChordsApproach(
+        min_confidence=0.80, min_duration_s=0.5
+    ).detect(ctx)
+    top_key, _ = loose_verdict.ranked[0]
+    assert top_key.tonic == "C"
+    assert top_key.mode == "Ionian"
+
+    # Default thresholds: only the middle G qualifies, both boundaries
+    # collapse to G → G keys win.
+    strict_verdict = BoundaryChordsApproach().detect(ctx)
+    top_key, _ = strict_verdict.ranked[0]
+    assert (
+        top_key.tonic == "G"
+    ), f"With strict thresholds only G qualifies; got {top_key.tonic}"
+
+
+def test_all_garbage_events_returns_empty_verdict() -> None:
+    """Every event fails at least one threshold → empty ranked list with
+    a populated reason. No exception. Negative case mandated by the spec."""
+    events = [
+        # Fails confidence (0.82 < 0.85).
+        _FakeChordEvent("D", start_time=0.0, end_time=0.75, confidence=0.82),
+        # Fails confidence AND duration.
+        _FakeChordEvent("C#", start_time=0.75, end_time=1.15, confidence=0.15),
+        # Fails duration (0.3s < 0.5s).
+        _FakeChordEvent("G", start_time=1.15, end_time=1.45, confidence=0.90),
+    ]
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
+
+    verdict = BoundaryChordsApproach().detect(ctx)
+
+    assert verdict.ranked == []
+    assert verdict.meta is not None
+    # Reason must be a non-empty string so callers can distinguish "no
+    # qualifying events" from "no events at all" / "no chroma" / etc.
+    assert verdict.meta.get("reason") == "no_qualifying_events"

--- a/tests/audio/_key_approaches/test_cadential.py
+++ b/tests/audio/_key_approaches/test_cadential.py
@@ -1,0 +1,242 @@
+"""Unit tests for the cadential approach.
+
+AC-03 rows 6 (V→i in Bm → B Aeolian wins), 7 (V→I in C major → C Ionian
+wins), and 8 (no cadence pattern → graceful empty verdict).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from harmonic_analysis.audio._key_approaches.cadential import CadentialApproach
+from harmonic_analysis.audio._key_ensemble import KeyDetectionContext
+
+
+@dataclass
+class _FakeChordEvent:
+    chord_label: str
+    start_time: float = 0.0
+    end_time: float = 1.0
+    confidence: float = 0.9
+    is_diatonic: bool = True
+
+
+def _chroma_stub() -> np.ndarray:
+    return np.ones(12, dtype=float) / 12.0
+
+
+def test_v_to_i_in_b_minor_scores_b_aeolian() -> None:
+    """F# → Bm cadence (V→i in B minor) → B is the top tonic root.
+
+    iteration_01_a contract relaxation: cadential is now mode-agnostic.
+    Both B Ionian and B Aeolian receive equal credit for any major-V →
+    B-rooted cadence. The previous assertion (`mode == "Aeolian"`)
+    encoded the BUGGY pre-fix behavior where cadential pre-decided mode
+    based on the resolved chord's quality; that's exactly what the
+    iteration_01_a fix eliminates. The relaxed assertion still pins
+    down the load-bearing claim — the cadence identifies B as the
+    tonic root — without re-asserting the bug.
+    """
+    events = [
+        _FakeChordEvent("D"),
+        _FakeChordEvent("F#"),  # V
+        _FakeChordEvent("Bm"),  # i
+    ]
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
+
+    verdict = CadentialApproach().detect(ctx)
+
+    assert verdict.name == "cadential"
+    assert len(verdict.ranked) > 0
+    top_key, top_score = verdict.ranked[0]
+    assert (
+        top_key.tonic == "B"
+    ), f"Expected B as top tonic root, got {top_key.tonic} {top_key.mode}"
+    assert top_key.mode in ("Ionian", "Aeolian"), (
+        f"Top mode should be one of Ionian/Aeolian after dual-credit; "
+        f"got {top_key.mode}"
+    )
+    assert top_score > 0.0
+
+
+def test_v_to_capital_i_in_c_major_scores_c_ionian() -> None:
+    """G → C cadence (V→I in C major) → C is the top tonic root.
+
+    iteration_01_a contract relaxation: cadential is mode-agnostic.
+    Both C Ionian and C Aeolian receive equal credit for the G→C cadence.
+    This test still pins down tonic-root identification (the only thing
+    cadential is responsible for) — the rest of the ensemble decides
+    Ionian vs Aeolian via K-S template fit and bass_dominance.
+    """
+    events = [
+        _FakeChordEvent("F"),
+        _FakeChordEvent("G"),  # V
+        _FakeChordEvent("C"),  # I
+    ]
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
+
+    verdict = CadentialApproach().detect(ctx)
+
+    top_key, _ = verdict.ranked[0]
+    assert (
+        top_key.tonic == "C"
+    ), f"Expected C as top tonic root, got {top_key.tonic} {top_key.mode}"
+    assert top_key.mode in ("Ionian", "Aeolian"), (
+        f"Top mode should be one of Ionian/Aeolian after dual-credit; "
+        f"got {top_key.mode}"
+    )
+
+
+def test_no_cadence_pattern_returns_empty_verdict() -> None:
+    """vi-IV-I-V-style loop with no V→I → empty verdict, no crash."""
+    events = [
+        _FakeChordEvent("Am"),
+        _FakeChordEvent("F"),
+        _FakeChordEvent("C"),
+        _FakeChordEvent("G"),  # ends on V, no V→I transition (G→Am earlier)
+    ]
+    # Note: Am→F has no cadential motion (vi→IV). F→C is plagal (IV→I)
+    # which we don't credit. C→G is anti-cadential (I→V).
+    # Only V→I (G→C) cadences count, and there isn't one in this sequence.
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
+
+    verdict = CadentialApproach().detect(ctx)
+
+    # Per the prepare-doc spec, "no V→i or V→I transition" → graceful
+    # empty/zero verdict. Empty ranked list is the chosen graceful form.
+    assert verdict.ranked == []
+
+
+def test_empty_chord_events_graceful() -> None:
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=[])
+    verdict = CadentialApproach().detect(ctx)
+    assert verdict.ranked == []
+
+
+def test_single_chord_returns_empty_verdict() -> None:
+    """One chord can't cadence — needs a transition."""
+    events = [_FakeChordEvent("C")]
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
+
+    verdict = CadentialApproach().detect(ctx)
+    assert verdict.ranked == []
+
+
+def test_multiple_cadences_strengthen_winner() -> None:
+    """Multiple V→I cadences on same tonic root → that root normalizes to 1.0.
+
+    iteration_01_a: cadential is mode-agnostic, so both C Ionian and
+    C Aeolian sit at score 1.0 after two G→C cadences. The relaxed
+    assertion still proves that the cadence-counted tonic root wins
+    overall and reaches the normalized maximum.
+    """
+    events = [
+        _FakeChordEvent("G"),  # V
+        _FakeChordEvent("C"),  # I
+        _FakeChordEvent("F"),
+        _FakeChordEvent("G"),  # V
+        _FakeChordEvent("C"),  # I
+    ]
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
+
+    verdict = CadentialApproach().detect(ctx)
+    top_key, top_score = verdict.ranked[0]
+    assert top_key.tonic == "C"
+    assert top_key.mode in ("Ionian", "Aeolian")
+    assert top_score == 1.0  # Top score normalized to 1.0
+
+
+# ---------------------------------------------------------------------------
+# iteration_01_a: dual-credit symmetry tests. After the fix, every
+# major-V → tonic resolution credits both Ionian and Aeolian of the
+# tonic root equally. These tests are the primary regression guard
+# against re-introducing the silent major-bias bug.
+# ---------------------------------------------------------------------------
+
+
+def _find_score(verdict, tonic: str, mode: str) -> float:
+    """Extract a single (tonic, mode) score from a verdict's ranked list."""
+    for k, s in verdict.ranked:
+        if k.tonic == tonic and k.mode == mode:
+            return s
+    raise AssertionError(
+        f"Did not find {tonic} {mode} in verdict.ranked — "
+        f"got tonics={[(k.tonic, k.mode) for k, _ in verdict.ranked[:6]]}"
+    )
+
+
+def test_v_to_i_minor_credits_both_modes_equally() -> None:
+    """F# → Bm cadence (V→i in B minor) credits B Ionian AND B Aeolian
+    with equal score. This is the primary regression guard for the
+    silent major-bias bug — pre-fix, B Aeolian got zero from this
+    progression while D Ionian (a relative-major detour) scored 1.000."""
+    events = [
+        _FakeChordEvent("F#"),  # major V
+        _FakeChordEvent("Bm"),  # minor i
+    ]
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
+
+    verdict = CadentialApproach().detect(ctx)
+
+    b_ionian = _find_score(verdict, "B", "Ionian")
+    b_aeolian = _find_score(verdict, "B", "Aeolian")
+    # Equal score — same integer count, same normalizer.
+    assert b_ionian == b_aeolian, (
+        f"Expected equal credit for B Ionian and B Aeolian after V→i; "
+        f"got Ionian={b_ionian}, Aeolian={b_aeolian}"
+    )
+    # Both should be at the maximum (1.0) since they're the only credited
+    # candidates. Locks down the normalization shape, not just symmetry.
+    assert b_ionian == 1.0
+    assert b_aeolian == 1.0
+
+
+def test_v_to_capital_i_major_credits_both_modes_equally() -> None:
+    """A → D cadence (V→I in D major) credits D Ionian AND D Aeolian
+    with equal score. Proves symmetry — the dual-credit isn't biased
+    toward minor either; cadential is genuinely mode-agnostic."""
+    events = [
+        _FakeChordEvent("A"),  # major V
+        _FakeChordEvent("D"),  # major I
+    ]
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
+
+    verdict = CadentialApproach().detect(ctx)
+
+    d_ionian = _find_score(verdict, "D", "Ionian")
+    d_aeolian = _find_score(verdict, "D", "Aeolian")
+    assert d_ionian == d_aeolian, (
+        f"Expected equal credit for D Ionian and D Aeolian after V→I; "
+        f"got Ionian={d_ionian}, Aeolian={d_aeolian}"
+    )
+    assert d_ionian == 1.0
+    assert d_aeolian == 1.0
+
+
+def test_no_v_motion_returns_empty_verdict() -> None:
+    """Negative case: a sequence with NO (major V → any tonic) adjacent
+    pairs must produce an empty verdict with a populated reason. Cadential
+    refuses to fabricate cadences from non-dominant motion.
+
+    Sequence walk-through (each pair must fail the V→tonic test):
+        Am (minor) → Em (minor): a is minor, skipped (only major V's
+            count as dominants).
+        Em (minor) → Am (minor): a is minor, skipped.
+        Am (minor) → Dm (minor): a is minor, skipped.
+    No major-V dominants in the sequence at all → no cadences.
+    """
+    events = [
+        _FakeChordEvent("Am"),
+        _FakeChordEvent("Em"),
+        _FakeChordEvent("Am"),
+        _FakeChordEvent("Dm"),
+    ]
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
+
+    verdict = CadentialApproach().detect(ctx)
+
+    assert verdict.ranked == []
+    assert verdict.meta is not None
+    assert verdict.meta.get("reason") == "no_cadences_detected"

--- a/tests/audio/test_key_ensemble.py
+++ b/tests/audio/test_key_ensemble.py
@@ -1,0 +1,213 @@
+"""Unit tests for the KeyEnsembleSynthesizer.
+
+AC-04: Synthesizer correctness — winner via weighted sum, margin formula,
+single-approach behavior, tie handling.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from harmonic_analysis.audio._key_ensemble import (
+    DEFAULT_WEIGHTS,
+    KeyDetectionVerdict,
+    KeyEnsembleSynthesizer,
+    resolve_preset,
+)
+from harmonic_analysis.audio._types import KeyInfo
+
+
+def _key(tonic: str, mode: str) -> KeyInfo:
+    """Quick KeyInfo factory."""
+    return KeyInfo(
+        tonic=tonic,
+        mode=mode,
+        key_signature=f"{tonic} {'major' if mode == 'Ionian' else 'minor'}",
+        confidence=0.5,
+    )
+
+
+def test_synthesizer_picks_weighted_sum_winner() -> None:
+    """approach-A: B Aeolian=0.9; approach-B: D Ionian=0.8; weights=1.0 → winner=B."""
+    b_aeolian = _key("B", "Aeolian")
+    d_ionian = _key("D", "Ionian")
+
+    verdict_a = KeyDetectionVerdict(
+        name="A",
+        ranked=[(b_aeolian, 0.9), (d_ionian, 0.5)],
+    )
+    verdict_b = KeyDetectionVerdict(
+        name="B",
+        ranked=[(d_ionian, 0.8), (b_aeolian, 0.4)],
+    )
+
+    weights = {"A": 1.0, "B": 1.0}
+    synth = KeyEnsembleSynthesizer()
+    result = synth.synthesize([verdict_a, verdict_b], weights=weights)
+
+    # B Aeolian totals: 0.9 * 1.0 + 0.4 * 1.0 = 1.3
+    # D Ionian totals : 0.5 * 1.0 + 0.8 * 1.0 = 1.3
+    # Tie! Whichever appears first in iteration order wins.
+    assert result.method == "weighted_sum"
+    # Both winners are valid given exact tie; just verify margin is 0
+    assert result.margin == 0.0
+
+
+def test_synthesizer_margin_is_winner_minus_runner_up() -> None:
+    """Clear winner → margin = winner_total - runner_up_total."""
+    b_aeolian = _key("B", "Aeolian")
+    d_ionian = _key("D", "Ionian")
+
+    verdict_a = KeyDetectionVerdict(
+        name="A",
+        ranked=[(b_aeolian, 0.9), (d_ionian, 0.3)],
+    )
+    verdict_b = KeyDetectionVerdict(
+        name="B",
+        ranked=[(b_aeolian, 0.7), (d_ionian, 0.4)],
+    )
+    weights = {"A": 1.0, "B": 1.0}
+
+    result = KeyEnsembleSynthesizer().synthesize(
+        [verdict_a, verdict_b], weights=weights
+    )
+
+    # B totals: 1.6; D totals: 0.7; margin: 0.9
+    assert result.winner.tonic == "B"
+    assert result.runner_up is not None
+    assert result.runner_up.tonic == "D"
+    assert result.margin == pytest.approx(0.9, rel=1e-6)
+
+
+def test_synthesizer_applies_per_approach_weights() -> None:
+    """Weight scaling: approach-B's vote at 2x flips the winner."""
+    b_aeolian = _key("B", "Aeolian")
+    d_ionian = _key("D", "Ionian")
+
+    verdict_a = KeyDetectionVerdict(
+        name="A", ranked=[(b_aeolian, 0.9), (d_ionian, 0.0)]
+    )
+    verdict_b = KeyDetectionVerdict(
+        name="B", ranked=[(d_ionian, 0.6), (b_aeolian, 0.0)]
+    )
+
+    # Equal weights: B wins (0.9 vs 0.6)
+    res_eq = KeyEnsembleSynthesizer().synthesize(
+        [verdict_a, verdict_b], weights={"A": 1.0, "B": 1.0}
+    )
+    assert res_eq.winner.tonic == "B"
+
+    # Boost B's weight to 2.0: D wins (0.9 vs 1.2)
+    res_boosted = KeyEnsembleSynthesizer().synthesize(
+        [verdict_a, verdict_b], weights={"A": 1.0, "B": 2.0}
+    )
+    assert res_boosted.winner.tonic == "D"
+
+
+def test_synthesizer_handles_single_verdict() -> None:
+    """Only one approach ran (e.g. ks_only) → no crash, runner_up may exist
+    from the same verdict's tail."""
+    b = _key("B", "Aeolian")
+    d = _key("D", "Ionian")
+    verdict = KeyDetectionVerdict(name="A", ranked=[(b, 0.9), (d, 0.5)])
+    weights = {"A": 1.0}
+
+    result = KeyEnsembleSynthesizer().synthesize([verdict], weights=weights)
+
+    assert result.winner.tonic == "B"
+    assert result.runner_up is not None
+    assert result.runner_up.tonic == "D"
+    assert result.margin == pytest.approx(0.4, rel=1e-6)
+
+
+def test_synthesizer_skips_zero_weight_approaches() -> None:
+    """Approach with weight 0.0 doesn't contribute to score table."""
+    b = _key("B", "Aeolian")
+    d = _key("D", "Ionian")
+    verdict_a = KeyDetectionVerdict(name="A", ranked=[(b, 0.9)])
+    verdict_b = KeyDetectionVerdict(name="B", ranked=[(d, 0.9)])
+
+    result = KeyEnsembleSynthesizer().synthesize(
+        [verdict_a, verdict_b], weights={"A": 1.0, "B": 0.0}
+    )
+
+    assert result.winner.tonic == "B"  # only A contributed
+    # B should not appear in the score table at all when its weight was 0
+    assert "D major" not in result.key_score_table
+
+
+def test_synthesizer_raises_on_empty_verdicts() -> None:
+    """Empty verdict list → ValueError (programming error, not graceful state)."""
+    with pytest.raises(ValueError):
+        KeyEnsembleSynthesizer().synthesize([])
+
+
+def test_synthesizer_per_approach_records_weights() -> None:
+    """SynthesisResult.per_approach reflects what was wired up."""
+    verdict = KeyDetectionVerdict(name="X", ranked=[(_key("C", "Ionian"), 1.0)])
+    result = KeyEnsembleSynthesizer().synthesize([verdict], weights={"X": 0.5})
+
+    assert result.per_approach == [("X", 0.5)]
+
+
+def test_synthesizer_handles_empty_ranked_lists() -> None:
+    """Some verdicts with empty ranked lists shouldn't crash; others contribute."""
+    b = _key("B", "Aeolian")
+    empty = KeyDetectionVerdict(name="empty", ranked=[])
+    populated = KeyDetectionVerdict(name="populated", ranked=[(b, 0.7)])
+
+    result = KeyEnsembleSynthesizer().synthesize(
+        [empty, populated], weights={"empty": 1.0, "populated": 1.0}
+    )
+
+    assert result.winner.tonic == "B"
+
+
+# ---- preset resolver tests ----
+
+
+def test_resolve_preset_default_returns_4_approaches() -> None:
+    names, weights = resolve_preset("default")
+    assert names == [
+        "template_correlation",
+        "boundary_chords",
+        "bass_dominance",
+        "cadential",
+    ]
+    assert weights == {n: DEFAULT_WEIGHTS[n] for n in names}
+
+
+def test_resolve_preset_ks_only_returns_one_approach() -> None:
+    names, weights = resolve_preset("ks_only")
+    assert names == ["template_correlation"]
+    assert weights == {"template_correlation": 1.0}
+
+
+def test_resolve_preset_full_includes_optins() -> None:
+    names, _weights = resolve_preset("full")
+    assert "pattern_engine" in names
+    assert "hmm" in names
+
+
+def test_resolve_preset_unknown_raises() -> None:
+    with pytest.raises(ValueError):
+        resolve_preset("kaboom")
+
+
+def test_resolve_preset_dict_uses_supplied_weights() -> None:
+    names, weights = resolve_preset(
+        {"template_correlation": 2.5, "boundary_chords": 0.1}
+    )
+    assert "template_correlation" in names
+    assert weights["template_correlation"] == 2.5
+
+
+def test_resolve_preset_list_uses_default_weights() -> None:
+    names, weights = resolve_preset(["template_correlation", "boundary_chords"])
+    assert names == ["template_correlation", "boundary_chords"]
+    assert weights["template_correlation"] == 1.0
+
+
+def test_resolve_preset_empty_list_raises() -> None:
+    with pytest.raises(ValueError):
+        resolve_preset([])

--- a/tests/audio/test_key_estimation.py
+++ b/tests/audio/test_key_estimation.py
@@ -119,6 +119,38 @@ def test_keyinfo_with_unsupported_mode_returns_empty_diatonic_set() -> None:
     assert ki.diatonic_pitch_classes == frozenset()
 
 
+def test_wrapper_delegates_to_template_correlation_approach() -> None:
+    """AC-02: ``find_best_key`` and ``TemplateCorrelationApproach.detect()``
+    must produce identical KeyInfo to 4 decimal places (bit-identity).
+
+    The wrapper is meant to be a literal one-liner — any drift here means
+    something is rounding twice or coercing in between.
+    """
+    from harmonic_analysis.audio._key_approaches.template_correlation import (
+        TemplateCorrelationApproach,
+    )
+    from harmonic_analysis.audio._key_ensemble import KeyDetectionContext
+
+    # Use the rolled-A K-S minor profile — exercises a non-zero pitch class
+    # and the minor-mode branch.
+    chroma = np.roll(np.array(KS_PROFILES["minor"], dtype=float), 9)
+
+    wrapper_result = find_best_key(chroma)
+    approach_result = (
+        TemplateCorrelationApproach()
+        .detect(KeyDetectionContext(chroma_1d=chroma))
+        .ranked[0][0]
+    )
+
+    # Bit identity to 4 decimal places per AC-02.
+    assert wrapper_result.tonic == approach_result.tonic
+    assert wrapper_result.mode == approach_result.mode
+    assert wrapper_result.key_signature == approach_result.key_signature
+    # Confidence already rounds to 4 dp inside the approach, so equality
+    # is the right check (not approx).
+    assert wrapper_result.confidence == approach_result.confidence
+
+
 def test_diatonic_pitch_classes_match_music21_for_all_keys() -> None:
     """One-time cross-check: every (tonic, mode) we support must produce a
     pitch-class set identical to music21's. Skips cleanly when music21 isn't

--- a/tests/integration/test_real_audio_key_detection.py
+++ b/tests/integration/test_real_audio_key_detection.py
@@ -1,0 +1,267 @@
+"""Real-audio regression test for the iteration_01 → iteration_01_a transition.
+
+This test was the missing safety net in iteration_01. The synthetic Bm
+fixture in ``test_relative_pair_disambiguation.py`` had clean equal-
+amplitude bass throughout the duration — the easy case for
+``bass_dominance``. That fixture *passed* in iteration_01 even with two
+algorithm bugs active in ``boundary_chords`` and ``cadential``, because
+clean fixture boundaries + clean bass + correct synthesizer math was
+enough to flip the verdict to B Aeolian. On real audio, both bugs
+mattered and the diagnostic recording produced ``D Ionian`` — the same
+wrong answer K-S alone gives — under the default ensemble.
+
+This file loads the actual diagnostic MP3 (``.local_docs/iwasonce_steinway.mp3``,
+the project owner's own recording) and asserts:
+
+    1. Default ensemble: ``global_key == B Aeolian``
+    2. ``ks_only``: ``global_key == D Ionian`` (proves the new defaults
+       are doing the disambiguation, not a backward-compat regression)
+    3. ``boundary_chords`` top-3 includes a B-rooted key
+    4. ``cadential`` top-3 includes a B-rooted key
+
+Negative cases (documented here as load-bearing comments rather than
+runtime asserts — reverting either fix below will fail one or more of
+the runtime asserts above):
+
+    * **Without Fix 1** (``boundary_chords`` filtering): the silent
+      lead-in (~1.35s of room tone before the music starts) produces a
+      ``D conf 0.82`` event from K-S's tonal_bias defaulting to the
+      global key. The trailing-decay tail produces a ``G conf 0.85``
+      event (or similar). With these as the literal first/last events,
+      ``boundary_chords`` votes for D and G keys; B is absent from its
+      top 3. See ``iteration_01/results.md:150`` for the exact pre-fix
+      output.
+
+    * **Without Fix 2** (``cadential`` V→i symmetry): F#→Bm progressions
+      (multiple in this recording — textbook V→i in B minor) score zero
+      for B Aeolian because the pre-fix code only credited the major
+      slot for major-tonic resolutions. A→D progressions in the
+      relative-major detour score 1.000 for D Ionian, contributing
+      +0.700 to the wrong answer. See ``iteration_01/results.md:158``
+      for the synthesis math; the cadential approach was the single
+      largest factor pushing the ensemble toward D Ionian pre-fix.
+
+The diagnostic MP3 is checked into ``.local_docs/`` (gitignored on most
+machines but present on developer workstations). On CI or any machine
+without the file, the entire module is skipped — these are developer-
+machine smoke tests, not gate-blocking CI tests. The synthetic fixture
+in ``test_relative_pair_disambiguation.py`` covers the easy case and
+runs everywhere; this file covers the hard case where it matters.
+
+iteration_01_a context: see
+``.agent_process/work/audio_score_alignment-02/iteration_01_a/iteration-feedback.md``
+and ``iteration_01/results.md:125-280`` for the full forensic analysis
+that produced these tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Skip the whole module if the audio extras aren't installed. Same
+# pattern as test_relative_pair_disambiguation.py — keeps non-audio
+# CI runs green even on developer machines that haven't pip installed
+# the audio extras.
+pytest.importorskip("librosa")
+pytest.importorskip("soundfile")
+
+
+# Diagnostic MP3 path. tests/integration/<this_file> is two parents
+# below the repo root, so .parent.parent.parent gets us back to root.
+_DIAGNOSTIC_MP3 = (
+    Path(__file__).resolve().parent.parent.parent
+    / ".local_docs"
+    / "iwasonce_steinway.mp3"
+)
+
+
+@pytest.fixture(scope="module")
+def diagnostic_mp3() -> Path:
+    """Return path to the diagnostic MP3, or skip if not present.
+
+    The file is only on developer machines (gitignored). Skipping in
+    its absence keeps this test from blocking CI while still failing
+    loudly on workstations where the recording lives.
+    """
+    if not _DIAGNOSTIC_MP3.exists():
+        pytest.skip(
+            f"Diagnostic recording not found at {_DIAGNOSTIC_MP3}. "
+            "This is a developer-machine smoke test; copy "
+            "iwasonce_steinway.mp3 into .local_docs/ to run it."
+        )
+    return _DIAGNOSTIC_MP3
+
+
+# ---------------------------------------------------------------------------
+# 1. Default ensemble produces B Aeolian.
+# ---------------------------------------------------------------------------
+
+
+async def test_default_ensemble_picks_b_aeolian_on_diagnostic(
+    diagnostic_mp3: Path,
+) -> None:
+    """Default ensemble must produce B Aeolian on the diagnostic recording.
+
+    Negative case (revert-guard documentation):
+        * Without Fix 1 (``boundary_chords`` filtering), the silent
+          lead-in produces a 'D conf 0.82' garbage boundary event,
+          dragging boundary_chords toward D keys.
+        * Without Fix 2 (``cadential`` V→i symmetry), F#→Bm cadences
+          score zero for B Aeolian while A→D cadences score 1.000
+          for D Ionian.
+        * Either reversion alone is enough to flip the ensemble back
+          to D Ionian. See iteration_01/results.md:170-177 for the
+          synthesis math showing how the bugs combined.
+    """
+    from harmonic_analysis import analyze_audio_async
+
+    result = await analyze_audio_async(
+        diagnostic_mp3, quiet=True, key_detection="default"
+    )
+
+    assert result.global_key.tonic == "B", (
+        f"Expected B (default ensemble disambiguates the relative pair "
+        f"on real audio), got {result.global_key.tonic} "
+        f"{result.global_key.mode}. This is the regression that "
+        f"iteration_01_a was created to prevent."
+    )
+    assert "Aeolian" in result.global_key.mode, (
+        f"Expected Aeolian mode (matches B minor), got " f"{result.global_key.mode}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. ks_only still produces D Ionian — backward compat preserved.
+# ---------------------------------------------------------------------------
+
+
+async def test_ks_only_picks_d_ionian_on_diagnostic(
+    diagnostic_mp3: Path,
+) -> None:
+    """``key_detection="ks_only"`` should still produce D Ionian.
+
+    This is the bit-identical pre-ensemble code path. If this test
+    starts producing B Aeolian, something has regressed in K-S itself
+    (the new defaults shouldn't touch the ks_only output). The
+    divergence between this verdict and the default verdict is the
+    direct evidence that the ensemble + per-approach fixes are doing
+    the disambiguation work, not a K-S regression.
+    """
+    from harmonic_analysis import analyze_audio_async
+
+    result = await analyze_audio_async(
+        diagnostic_mp3, quiet=True, key_detection="ks_only"
+    )
+
+    assert result.global_key.tonic == "D", (
+        f"Expected D (K-S leans relative-major on this recording), got "
+        f"{result.global_key.tonic} {result.global_key.mode}. If this "
+        f"changed, something regressed in K-S template_correlation."
+    )
+    assert "Ionian" in result.global_key.mode, (
+        f"Expected Ionian (K-S labels major as Ionian), got "
+        f"{result.global_key.mode}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3 + 4. With diagnostic panel: boundary_chords AND cadential top-3 each
+#         include a B-rooted key. These are the per-approach assertions
+#         that lock down the algorithm fixes — even if synthesis happens
+#         to land on B for the wrong reasons, these tests catch a
+#         per-approach regression before it can hide under the synthesizer.
+# ---------------------------------------------------------------------------
+
+
+def _b_rooted_in_top3(approach_entry: dict) -> bool:
+    """True if any B-rooted KeyInfo appears in the approach's top_3 list."""
+    for candidate in approach_entry.get("top_3", []):
+        # top_3 entries are dicts with a 'key' subdict containing 'tonic'
+        # and 'mode'. Schema documented in docs/reference/audio-api.md.
+        key_dict = candidate.get("key", {}) if isinstance(candidate, dict) else {}
+        if key_dict.get("tonic") == "B":
+            return True
+    return False
+
+
+def _find_approach(details: dict, name: str) -> dict:
+    """Locate the approach entry by name in the diagnostic panel."""
+    for entry in details.get("approaches", []):
+        if entry.get("name") == name:
+            return entry
+    raise AssertionError(
+        f"approach {name!r} not in diagnostic panel; "
+        f"got names={[a.get('name') for a in details.get('approaches', [])]}"
+    )
+
+
+async def test_default_diagnostics_show_b_rooted_in_boundary_chords(
+    diagnostic_mp3: Path,
+) -> None:
+    """boundary_chords top-3 must include a B-rooted key (Ionian or Aeolian).
+
+    Negative case: without Fix 1 (the iteration_01_a confidence/
+    duration filter), boundary_chords used the literal first/last
+    events — D from the silent lead-in and G/C# from the decay tail.
+    Its top-3 in iteration_01 was ``C# Aeolian / D Ionian / C# Ionian``;
+    no B keys at all (see iteration_01/results.md:150).
+    """
+    from harmonic_analysis import analyze_audio_async
+
+    result = await analyze_audio_async(
+        diagnostic_mp3,
+        quiet=True,
+        key_detection="default",
+        show_analysis_details=True,
+    )
+
+    details = result.key_analysis_details
+    assert details is not None, "show_analysis_details=True must populate panel"
+
+    bc = _find_approach(details, "boundary_chords")
+    assert _b_rooted_in_top3(bc), (
+        f"Expected at least one B-rooted key in boundary_chords top_3 "
+        f"(filtered boundaries should both be Bm); got "
+        f"{[c.get('key', {}) for c in bc.get('top_3', [])]}. "
+        "Likely cause: Fix 1 (min_confidence/min_duration_s filter) "
+        "is not active or thresholds are too loose."
+    )
+
+
+async def test_default_diagnostics_show_b_rooted_in_cadential(
+    diagnostic_mp3: Path,
+) -> None:
+    """cadential top-3 must include a B-rooted key (Ionian or Aeolian).
+
+    Negative case: without Fix 2 (mode-agnostic dual-credit), F#→Bm
+    progressions credited only Aeolian under the old branch logic but
+    only when the resolved chord was minor — and there's an interaction
+    bug where the simultaneous A→D progressions credited only D Ionian,
+    pushing D Ionian to a perfect 1.000 normalized score and B Aeolian
+    to zero. cadential's top-3 in iteration_01 was
+    ``D Ionian / G Ionian / B Ionian`` (no Aeolian B; see
+    iteration_01/results.md:158-160). After Fix 2 both B Ionian and
+    B Aeolian receive credit equally.
+    """
+    from harmonic_analysis import analyze_audio_async
+
+    result = await analyze_audio_async(
+        diagnostic_mp3,
+        quiet=True,
+        key_detection="default",
+        show_analysis_details=True,
+    )
+
+    details = result.key_analysis_details
+    assert details is not None
+
+    cad = _find_approach(details, "cadential")
+    assert _b_rooted_in_top3(cad), (
+        f"Expected at least one B-rooted key in cadential top_3 "
+        f"(F#→Bm progressions in the recording should credit B keys); "
+        f"got {[c.get('key', {}) for c in cad.get('top_3', [])]}. "
+        "Likely cause: Fix 2 (dual-credit Ionian + Aeolian on every "
+        "major-V resolution) is not active."
+    )

--- a/tests/integration/test_relative_pair_disambiguation.py
+++ b/tests/integration/test_relative_pair_disambiguation.py
@@ -1,0 +1,315 @@
+"""Integration test: ensemble disambiguates relative major/minor pairs.
+
+The diagnostic recording that motivated this scope (`iwasonce_steinway.mp3`)
+plays in B minor but Krumhansl-Schmuckler returns D major. K-S can't tell
+relative pairs apart — they share pitch-class sets. The fix is the
+ensemble: boundary chords on Bm + bass dominance at B + cadential V→i
+patterns all break the tie toward B Aeolian.
+
+This test constructs a synthetic WAV fixture that exhibits the same
+property:
+  * Time-averaged chroma is balanced enough that K-S leans D major
+  * First and last chord events parse as Bm (boundary_chords vote)
+  * Bass register dominates pitch class B (bass_dominance vote)
+  * V→i patterns appear (F# → Bm transitions, cadential vote)
+
+Under ``key_detection="default"`` (full ensemble), the verdict should be
+B Aeolian. Under ``key_detection="ks_only"``, the verdict reverts to
+whatever the K-S correlation returns — proving the ensemble is doing
+the disambiguation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Skip the whole module if the audio extras aren't installed.
+pytest.importorskip("librosa")
+pytest.importorskip("soundfile")
+
+
+def _generate_bm_diagnostic_wav(
+    path: Path, duration_sec: float = 12.0, sr: int = 22050
+) -> Path:
+    """Synthesize a WAV that demonstrates the relative-pair problem.
+
+    The construction goal: K-S correlation alone must lean D major; the
+    ensemble must lean B Aeolian. Achieving this means tilting the chroma
+    statistics toward D-major-prominent pitches (lots of D, F#, A) while
+    keeping the chord events at the boundaries clearly Bm.
+
+    Strategy:
+      * Most of the time is in D-major content (heavy A and D).
+      * Bookend chords (start ~1s and end ~1s) read as Bm via chord
+        estimation (B2 + D3 + F#3 stack — bass-heavy enough for the
+        chord template matcher to label it Bm).
+      * In between, a long D-major section establishes the chroma
+        average that K-S uses.
+      * V→i cadence (F# → Bm) at the close.
+
+    The rest of the music-theory rationalization writes itself: this is
+    a piece in B minor that spends most of its time on the relative
+    major (vi → III in B minor terms).
+    """
+    sf = pytest.importorskip("soundfile")
+
+    # Pitch frequencies (concert pitch). The bass register matters for
+    # the chord-estimator's boundary labels (Bm at the start/end), but
+    # the time-averaged chroma — which is what K-S sees — gets dominated
+    # by whatever pitches we sustain longest. Keep Bm sections short.
+    notes = {
+        "B2": 123.47,
+        "D3": 146.83,
+        "F#3": 185.00,
+        "A3": 220.00,
+        "B3": 246.94,
+        "A#3": 233.08,
+        "C#4": 277.18,
+        "E3": 164.81,
+        "G3": 196.00,
+        "D4": 293.66,
+    }
+
+    def _chord(
+        freqs: list[float], dur: float, weights: list[float] | None = None
+    ) -> np.ndarray:
+        t = np.linspace(0.0, dur, int(sr * dur), endpoint=False)
+        if weights is None:
+            weights = [1.0] * len(freqs)
+        sig = np.zeros_like(t)
+        for f, w in zip(freqs, weights):
+            sig += w * np.sin(2 * np.pi * f * t)
+        return sig / max(sum(weights), 1.0)
+
+    sections = []
+
+    # Bookend opener: Bm (1.0s). Short — we want the chord estimator
+    # to see "Bm" but K-S not to overweight B.
+    sections.append(
+        _chord(
+            [notes["B2"], notes["D3"], notes["F#3"]],
+            1.0,
+            weights=[1.5, 1.0, 1.0],
+        )
+    )
+
+    # Long D-major-content stretch (5.0s total). This is the chroma-mass
+    # section that pushes K-S toward D Ionian. We rotate through D-major
+    # diatonic chords with bass A and D dominating — keeps the bass
+    # register pointing at A/D, not B. Time-averaging means whichever
+    # chord we play longest wins K-S.
+    # D major (D-F#-A) for 1.5s with A in bass to lift A-class.
+    sections.append(
+        _chord(
+            [notes["A3"], notes["D4"], notes["F#3"]],
+            1.5,
+            weights=[2.0, 1.0, 1.0],
+        )
+    )
+    # G major (G-B-D) for 1.0s. G is part of D-major diatonic but adds B.
+    sections.append(
+        _chord(
+            [notes["G3"], notes["D4"], notes["F#3"]],
+            1.0,
+            weights=[1.5, 1.0, 0.7],
+        )
+    )
+    # A major (A-C#-E) for 1.5s — the V chord of D major, heavy on A.
+    sections.append(
+        _chord(
+            [notes["A3"], notes["C#4"], notes["E3"]],
+            1.5,
+            weights=[2.0, 1.0, 1.2],
+        )
+    )
+    # D major resolution (1.0s) — D Ionian's I chord.
+    sections.append(
+        _chord(
+            [notes["D3"], notes["F#3"], notes["A3"]],
+            1.0,
+            weights=[1.5, 1.0, 1.0],
+        )
+    )
+
+    # F# major (V of B minor) — 1.0s. Cadence setup. F# + A# + C#.
+    sections.append(
+        _chord(
+            [notes["F#3"], notes["A#3"], notes["C#4"]],
+            1.0,
+            weights=[1.3, 1.0, 1.0],
+        )
+    )
+
+    # Bm cadence resolution (i in B minor) — 1.0s.
+    sections.append(
+        _chord(
+            [notes["B2"], notes["D3"], notes["F#3"]],
+            1.0,
+            weights=[1.5, 1.0, 1.0],
+        )
+    )
+
+    # Bookend closer: Bm again (1.0s).
+    sections.append(
+        _chord(
+            [notes["B2"], notes["D3"], notes["F#3"]],
+            1.0,
+            weights=[1.5, 1.0, 1.0],
+        )
+    )
+
+    signal = np.concatenate(sections)
+    signal = (signal * 0.45).astype(np.float32)
+    sf.write(str(path), signal, sr)
+    return path
+
+
+@pytest.fixture
+def bm_diagnostic_wav(tmp_path: Path) -> Path:
+    return _generate_bm_diagnostic_wav(tmp_path / "bm_diagnostic.wav")
+
+
+# ---------------------------------------------------------------------------
+# AC-01: default ensemble produces B Aeolian; ks_only produces something
+# different (typically D major). The point is the divergence — the ensemble
+# is doing real work.
+# ---------------------------------------------------------------------------
+async def test_default_ensemble_picks_b_aeolian(
+    bm_diagnostic_wav: Path,
+) -> None:
+    """``key_detection="default"`` should pick B Aeolian on the Bm fixture."""
+    from harmonic_analysis import analyze_audio_async
+
+    result = await analyze_audio_async(
+        bm_diagnostic_wav, quiet=True, key_detection="default"
+    )
+
+    assert result.global_key.tonic == "B", (
+        f"Expected B (default ensemble disambiguates relative pair), "
+        f"got {result.global_key.tonic} {result.global_key.mode}"
+    )
+    assert (
+        "Aeolian" in result.global_key.mode
+    ), f"Expected Aeolian mode, got {result.global_key.mode}"
+
+
+async def test_ks_only_diverges_from_default(
+    bm_diagnostic_wav: Path,
+) -> None:
+    """``ks_only`` must give a DIFFERENT answer from default on this fixture.
+
+    The exact tonic depends on chroma weighting — typically D, sometimes
+    F# major or A major. Whatever it is, it must not be B Aeolian (else
+    the fixture doesn't exercise the relative-pair problem we're trying
+    to test).
+    """
+    from harmonic_analysis import analyze_audio_async
+
+    ks_result = await analyze_audio_async(
+        bm_diagnostic_wav, quiet=True, key_detection="ks_only"
+    )
+    default_result = await analyze_audio_async(
+        bm_diagnostic_wav, quiet=True, key_detection="default"
+    )
+
+    # The ks_only verdict and the default verdict must differ —
+    # otherwise the ensemble isn't doing any disambiguation work.
+    assert (ks_result.global_key.tonic, ks_result.global_key.mode) != (
+        default_result.global_key.tonic,
+        default_result.global_key.mode,
+    ), (
+        f"Fixture failed to exercise the ensemble: ks_only and default "
+        f"both returned {ks_result.global_key.tonic} {ks_result.global_key.mode}"
+    )
+
+
+async def test_show_analysis_details_populates_payload(
+    bm_diagnostic_wav: Path,
+) -> None:
+    """AC-05: show_analysis_details=True populates structured breakdown."""
+    from harmonic_analysis import analyze_audio_async
+
+    result = await analyze_audio_async(
+        bm_diagnostic_wav,
+        quiet=True,
+        key_detection="default",
+        show_analysis_details=True,
+    )
+
+    details = result.key_analysis_details
+    assert details is not None, "key_analysis_details should be populated"
+    assert "approaches" in details
+    assert "synthesis" in details
+    assert "modulations" in details
+
+    # Each approach entry must have name, weight, top_3
+    assert len(details["approaches"]) > 0
+    for approach in details["approaches"]:
+        assert "name" in approach
+        assert "weight" in approach
+        assert "top_3" in approach
+        assert isinstance(approach["top_3"], list)
+
+    # Synthesis dict has the documented keys
+    synth = details["synthesis"]
+    assert "method" in synth
+    assert "winner" in synth
+    assert "runner_up" in synth
+    assert "margin" in synth
+    assert "key_score_table" in synth
+
+    # iteration_01 doesn't ship HMM, so modulations is None
+    assert details["modulations"] is None
+
+
+async def test_show_analysis_details_default_keeps_payload_none(
+    bm_diagnostic_wav: Path,
+) -> None:
+    """AC-06: show_analysis_details defaults to False; payload is None."""
+    from harmonic_analysis import analyze_audio_async
+
+    # Explicit False
+    res_explicit = await analyze_audio_async(
+        bm_diagnostic_wav,
+        quiet=True,
+        key_detection="default",
+        show_analysis_details=False,
+    )
+    assert res_explicit.key_analysis_details is None
+
+    # Default (omitted)
+    res_default = await analyze_audio_async(bm_diagnostic_wav, quiet=True)
+    assert res_default.key_analysis_details is None
+
+
+async def test_ks_only_with_details_shows_single_approach(
+    bm_diagnostic_wav: Path,
+) -> None:
+    """AC-05 corner: ks_only + details on → exactly one approach in the panel."""
+    from harmonic_analysis import analyze_audio_async
+
+    result = await analyze_audio_async(
+        bm_diagnostic_wav,
+        quiet=True,
+        key_detection="ks_only",
+        show_analysis_details=True,
+    )
+    assert result.key_analysis_details is not None
+    approaches = result.key_analysis_details["approaches"]
+    assert len(approaches) == 1
+    assert approaches[0]["name"] == "template_correlation"
+
+
+async def test_invalid_key_detection_preset_raises(
+    bm_diagnostic_wav: Path,
+) -> None:
+    """Unknown preset string should raise ValueError at construction."""
+    from harmonic_analysis import analyze_audio_async
+
+    with pytest.raises(ValueError):
+        await analyze_audio_async(
+            bm_diagnostic_wav, quiet=True, key_detection="nonexistent_preset"
+        )


### PR DESCRIPTION
## Summary

Cuts beta `v0.3.1-beta.2` from `scope/audio_score_alignment-02`. Promotes everything currently in `[Unreleased]` to a versioned beta entry — bundles the audio_score_alignment-02 fixes on top of the bass-chroma / rubato / silence-suppression work that was already staged.

## What's in this beta

### Fixed
- **Relative minor/major key confusion** — the ensemble key detector was reporting D Ionian on recordings that were clearly in B Aeolian. `boundary_chords` was letting low-confidence edge events vote on the key, and `cadential` was treating V→i (minor resolutions) as a poor relation of V→I. Both fixed. (#34)
- **Phantom chord events during silent audio** — windows below the new `min_chroma_norm=0.05` threshold are skipped, so leading silence stops generating spurious chord detections.

### Added
- **Bass-aware chord estimation** (`use_bass_chroma` parameter) — disambiguates slash chords and inversions.
- **Rubato temporal flexibility** (`rubato` parameter) — four named presets or a float in `[0.0, 1.0]`.
- **Real-audio regression tests** — four integration tests against `iwasonce_steinway.mp3` plus approach-level unit tests for boundary filtering and cadential parity.

### Changed
- Audio analysis docs updated for the new parameters and design rationale.

## Test plan
- [x] Unit tests pass: `pytest tests/audio/_key_approaches/`
- [x] Real-audio integration tests pass: `pytest tests/integration/test_real_audio_key_detection.py`
- [x] Default ensemble produces B Aeolian on diagnostic MP3 (was D Ionian)
- [x] Backward compatibility: `ks_only` mode still produces D Ionian
- [ ] Manual verify on additional minor-key recordings before promoting to stable

## Metadata
- **Scope:** audio_score_alignment-02
- **Iteration:** iteration_01_a
- **Build:** 6
- **Beta tag:** v0.3.1-beta.2
- **Issue:** #34