### PR TITLE
audio: variable-tempo regions, adaptive silence gate, modal cadences

### DIFF
--- a/demo/backend/rest_api/models.py
+++ b/demo/backend/rest_api/models.py
@@ -247,6 +247,28 @@ class _SegmentModel(BaseModel):
     end: float
 
 
+class _TempoRegionModel(BaseModel):
+    """One constant-tempo span detected during variable-tempo analysis."""
+
+    start_time: float
+    end_time: float
+    bpm: float
+    confidence: float
+
+
+class _TempoModel(BaseModel):
+    """BPM metadata for the analyzed segment.
+
+    Populated when ``rubato="auto"`` triggered tempo detection. ``regions``
+    is empty for stable-tempo material (one region or detection failure);
+    multiple entries appear when the music has sustained tempo changes.
+    """
+
+    bpm: float
+    confidence: float
+    regions: List[_TempoRegionModel] = []
+
+
 class AudioAnalysisResponse(BaseModel):
     """Shape of the JSON returned by POST /api/analyze/audio.
 
@@ -260,6 +282,7 @@ class AudioAnalysisResponse(BaseModel):
     analysis: _AnalysisModel
     chord_progression: List[ChordEventModel]
     segment: _SegmentModel
+    tempo: Optional[_TempoModel] = None
     key_analysis_details: Optional["KeyAnalysisDetails"] = None
 
     model_config = {"populate_by_name": True}

--- a/demo/backend/rest_api/routes.py
+++ b/demo/backend/rest_api/routes.py
@@ -421,11 +421,24 @@ async def analyze_audio_endpoint(
     start: Optional[float] = Form(None),
     end: Optional[float] = Form(None),
     show_details: bool = Form(False),
+    # ── Key detection (ensemble) ───────────────────────────────────────
     key_detection: str = Form("default"),
     key_ensemble_weights: Optional[str] = Form(None),
+    # ── Timing & tempo ────────────────────────────────────────────────
+    rubato: str = Form("auto"),
+    tempo_region_threshold: Optional[float] = Form(None),
+    # ── Chord matching ────────────────────────────────────────────────
     tonal_bias: Optional[float] = Form(None),
     bass_bonus: Optional[float] = Form(None),
     use_bass_chroma: Optional[bool] = Form(None),
+    bass_confidence_threshold: Optional[float] = Form(None),
+    # ── Silence detection ─────────────────────────────────────────────
+    rms_silence_threshold: Optional[float] = Form(None),
+    trailing_silence_window_s: Optional[float] = Form(None),
+    trailing_silence_ratio: Optional[float] = Form(None),
+    # ── Chord consolidation ───────────────────────────────────────────
+    merge_same_root: Optional[bool] = Form(None),
+    max_merge_duration_s: Optional[float] = Form(None),
 ) -> Dict[str, Any]:
     """
     Analyze an audio file (WAV, MP3, etc.) for key, chords, and cadences.
@@ -454,6 +467,12 @@ async def analyze_audio_endpoint(
         use_bass_chroma: Optional bool. Extract bass-register chroma for
             root-disambiguation; helps separate Am vs C, Bm vs D. Library
             default is ``False``. ``None`` lets the library pick.
+        rubato: Chord-window timing preset. ``"auto"`` (default) detects
+            BPM and sizes the analysis window dynamically — typically the
+            best choice across genres. Static presets (``"strict"``,
+            ``"moderate"``, ``"loose"``, ``"free"``) override auto for
+            callers who want a fixed window grid. A float 0.0–1.0
+            interpolates between strict and free.
     """
     # Import guard — audio deps are optional; fail loudly with install hint
     try:
@@ -528,6 +547,24 @@ async def analyze_audio_endpoint(
         # Build segment tuple if the caller specified a window
         segment = (start, end) if start is not None else None
 
+        # Parse rubato. Accept "auto" plus the static presets and any
+        # float in [0, 1] (passed as a string from the form encoding).
+        # Bad input gets a 400 with a useful message.
+        valid_rubato_presets = {"auto", "strict", "moderate", "loose", "free"}
+        parsed_rubato: Any = rubato
+        if rubato not in valid_rubato_presets:
+            try:
+                parsed_rubato = float(rubato)
+            except (TypeError, ValueError):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Invalid rubato value {rubato!r}. "
+                        f"Valid presets: {sorted(valid_rubato_presets)} or a "
+                        f"float 0.0-1.0."
+                    ),
+                )
+
         # Build the kwargs dict so we only pass through the optional tuning
         # parameters when the caller actually set them. Letting None hit the
         # library would clobber its calibrated defaults.
@@ -536,13 +573,43 @@ async def analyze_audio_endpoint(
             "key_detection": parsed_key_detection,
             "show_analysis_details": show_details,
             "key_ensemble_weights": parsed_weights,
+            "rubato": parsed_rubato,
         }
+        # Pass through every advanced knob the caller actually set;
+        # leave the rest at library defaults. Grouped by phase below
+        # to mirror the demo UI's organization.
+
+        # Chord matching
         if tonal_bias is not None:
             analyze_kwargs["tonal_bias"] = float(tonal_bias)
         if bass_bonus is not None:
             analyze_kwargs["bass_bonus"] = float(bass_bonus)
         if use_bass_chroma is not None:
             analyze_kwargs["use_bass_chroma"] = bool(use_bass_chroma)
+        if bass_confidence_threshold is not None:
+            analyze_kwargs["bass_confidence_threshold"] = float(
+                bass_confidence_threshold
+            )
+
+        # Silence detection
+        if rms_silence_threshold is not None:
+            analyze_kwargs["rms_silence_threshold"] = float(rms_silence_threshold)
+        if trailing_silence_window_s is not None:
+            analyze_kwargs["trailing_silence_window_s"] = float(
+                trailing_silence_window_s
+            )
+        if trailing_silence_ratio is not None:
+            analyze_kwargs["trailing_silence_ratio"] = float(trailing_silence_ratio)
+
+        # Chord consolidation
+        if merge_same_root is not None:
+            analyze_kwargs["merge_same_root"] = bool(merge_same_root)
+        if max_merge_duration_s is not None:
+            analyze_kwargs["max_merge_duration_s"] = float(max_merge_duration_s)
+
+        # Variable-tempo region detection
+        if tempo_region_threshold is not None:
+            analyze_kwargs["tempo_region_threshold"] = float(tempo_region_threshold)
 
         try:
             result = await analyze_audio_async(temp_file_path, **analyze_kwargs)
@@ -589,6 +656,25 @@ async def analyze_audio_endpoint(
                 "end": result.segment_end,
             },
         }
+
+        # Tempo metadata — populated only when rubato="auto" triggered
+        # detection. Older clients ignore unknown fields, so this is
+        # additive. ``regions`` is empty when the tempo was stable
+        # through the segment (single-region or detection failure).
+        if result.tempo is not None:
+            response["tempo"] = {
+                "bpm": float(result.tempo.bpm),
+                "confidence": float(result.tempo.confidence),
+                "regions": [
+                    {
+                        "start_time": float(r.start_time),
+                        "end_time": float(r.end_time),
+                        "bpm": float(r.bpm),
+                        "confidence": float(r.confidence),
+                    }
+                    for r in result.tempo.regions
+                ],
+            }
 
         # Conditionally include the diagnostic panel. When show_details is
         # off, the response shape is unchanged from the pre-ensemble

--- a/demo/frontend/src/api/analysis.ts
+++ b/demo/frontend/src/api/analysis.ts
@@ -70,10 +70,37 @@ export const analyzeAudio = async (
   }
   // Pass the chord-estimation tuning knobs through only when the caller set
   // them. Omitting these lets the library use its calibrated defaults.
+  // Default to "auto" so demo users get tempo-adaptive chord windows
+  // out of the box. Static presets (or a float) override.
+  formData.append('rubato', String(options.rubato ?? 'auto'));
+  if (options.tempoRegionThreshold != null) {
+    formData.append('tempo_region_threshold', String(options.tempoRegionThreshold));
+  }
+  // Chord-matching knobs
   if (options.tonalBias != null) formData.append('tonal_bias', String(options.tonalBias));
   if (options.bassBonus != null) formData.append('bass_bonus', String(options.bassBonus));
   if (options.useBassChroma != null) {
     formData.append('use_bass_chroma', options.useBassChroma ? 'true' : 'false');
+  }
+  if (options.bassConfidenceThreshold != null) {
+    formData.append('bass_confidence_threshold', String(options.bassConfidenceThreshold));
+  }
+  // Silence-detection knobs
+  if (options.rmsSilenceThreshold != null) {
+    formData.append('rms_silence_threshold', String(options.rmsSilenceThreshold));
+  }
+  if (options.trailingSilenceWindowS != null) {
+    formData.append('trailing_silence_window_s', String(options.trailingSilenceWindowS));
+  }
+  if (options.trailingSilenceRatio != null) {
+    formData.append('trailing_silence_ratio', String(options.trailingSilenceRatio));
+  }
+  // Chord-consolidation knobs
+  if (options.mergeSameRoot != null) {
+    formData.append('merge_same_root', options.mergeSameRoot ? 'true' : 'false');
+  }
+  if (options.maxMergeDurationS != null) {
+    formData.append('max_merge_duration_s', String(options.maxMergeDurationS));
   }
 
   const response = await apiClient.post<AudioAnalysisResponse>(

--- a/demo/frontend/src/components/audio/HeadlinePanel.tsx
+++ b/demo/frontend/src/components/audio/HeadlinePanel.tsx
@@ -4,7 +4,7 @@
 // same family as the manual-entry hero card; just sized differently to express
 // the global/local hierarchy.
 
-import type { EnrichedAudioResult } from '../../types/audio';
+import type { AudioTempo, EnrichedAudioResult } from '../../types/audio';
 import SectionCard from '../ui/SectionCard';
 import KeySignatureGlyph from '../ui/KeySignatureGlyph';
 import ConfidenceBar from '../ui/ConfidenceBar';
@@ -106,18 +106,30 @@ const HeadlinePanel = ({ result }: HeadlinePanelProps) => {
         </div>
       </div>
 
-      {/* Three-cell meta strip: region · cadence · borrowed tones */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-slate-200 border-t border-slate-200">
-        <RegionCell
-          regionType={l.region_type}
-          regionConfidence={l.region_confidence}
-        />
-        <CadenceCell
-          detected={analysis.cadence_detected}
-          strength={analysis.cadence_strength}
-        />
-        <BorrowedCell labels={borrowedLabels} />
-      </div>
+      {/* Meta strip: region · cadence · borrowed tones (· tempo when detected).
+          Tempo cell only renders when auto-rubato produced a confident BPM —
+          static-rubato analyses skip detection and have no tempo to show. */}
+      {(() => {
+        const showTempo =
+          result.tempo !== undefined && result.tempo.confidence >= 0.3;
+        const cols = showTempo ? 'sm:grid-cols-2 lg:grid-cols-4' : 'sm:grid-cols-3';
+        return (
+          <div className={`grid grid-cols-1 ${cols} divide-y sm:divide-y-0 sm:divide-x divide-slate-200 border-t border-slate-200`}>
+            <RegionCell
+              regionType={l.region_type}
+              regionConfidence={l.region_confidence}
+            />
+            <CadenceCell
+              detected={analysis.cadence_detected}
+              strength={analysis.cadence_strength}
+            />
+            <BorrowedCell labels={borrowedLabels} />
+            {showTempo && result.tempo && (
+              <TempoCell tempo={result.tempo} />
+            )}
+          </div>
+        );
+      })()}
 
       <div className="p-6 border-t border-slate-100 bg-slate-50/40">
         <PedagogyNote title="Reading the panel">
@@ -171,6 +183,27 @@ const BorrowedCell = ({ labels }: { labels: string[] }) => {
       sub={has ? labels.slice(0, 4).join(' · ') + (labels.length > 4 ? ' …' : '') : 'All chords are diatonic'}
     />
   );
+};
+
+const TempoCell = ({ tempo }: { tempo: AudioTempo }) => {
+  const variable = tempo.regions.length > 1;
+  // Color the dot by stability — steady tempo gets emerald, variable
+  // gets indigo (matches the modulation color in the region cell).
+  const dot = variable ? 'bg-indigo-500' : 'bg-emerald-500';
+  // The headline is the global BPM rounded; the sub line either confirms
+  // stability or summarizes the regions.
+  const headline = `${Math.round(tempo.bpm)} BPM`;
+  let sub: string;
+  if (variable) {
+    // Show the BPM range across regions for at-a-glance variation.
+    const bpms = tempo.regions.map((r) => r.bpm);
+    const lo = Math.round(Math.min(...bpms));
+    const hi = Math.round(Math.max(...bpms));
+    sub = `${tempo.regions.length} regions · ${lo}–${hi} BPM`;
+  } else {
+    sub = `Stable · confidence ${(tempo.confidence * 100).toFixed(0)}%`;
+  }
+  return <MetaCell eyebrow="Tempo" headline={headline} dot={dot} sub={sub} />;
 };
 
 const MetaCell = ({

--- a/demo/frontend/src/components/audio/UploadCard.tsx
+++ b/demo/frontend/src/components/audio/UploadCard.tsx
@@ -9,7 +9,7 @@
 // We don't manage results inside this card — the parent Tab3 shows them.
 
 import { useEffect, useState } from 'react';
-import type { AnalyzeAudioOptions, KeyDetectionPreset } from '../../types/audio';
+import type { AnalyzeAudioOptions, KeyDetectionPreset, RubatoPreset } from '../../types/audio';
 import SectionCard from '../ui/SectionCard';
 import Tag from '../ui/Tag';
 import Eyebrow from '../ui/Eyebrow';
@@ -38,12 +38,38 @@ interface AdvancedConfig {
   segStart: number;
   segEnd: number;
   weights: Record<string, number>;
+
+  // Timing & tempo
+  /** Chord-window timing preset. "auto" detects BPM and sizes
+   *  the window dynamically; static presets fix the window grid. */
+  rubato: RubatoPreset;
+  /** Fractional BPM divergence above which auto-rubato emits a separate
+   *  region. null = use library default. */
+  tempoRegionThreshold: number | null;
+
+  // Chord matching
   /** Diatonic similarity bonus, 0–0.5. null = use library default. */
   tonalBias: number | null;
   /** Bass-register root-match bonus, 0–1. null = use library default. */
   bassBonus: number | null;
   /** Whether to extract bass-register chroma. null = use library default. */
   useBassChroma: boolean | null;
+  /** Min bass-chroma peakiness to fire the bonus. null = use default. */
+  bassConfidenceThreshold: number | null;
+
+  // Silence detection
+  /** Absolute RMS floor (linear). null = library default. */
+  rmsSilenceThreshold: number | null;
+  /** Trailing-window length in seconds. null = default. */
+  trailingSilenceWindowS: number | null;
+  /** Threshold as fraction of trailing-window mean RMS. null = default. */
+  trailingSilenceRatio: number | null;
+
+  // Chord consolidation
+  /** Merge adjacent same-root events into one. null = library default. */
+  mergeSameRoot: boolean | null;
+  /** Max merged-event duration (seconds). null = default. */
+  maxMergeDurationS: number | null;
 }
 
 // Library defaults for the chord-estimation tuning knobs. Same DRY caveat as
@@ -52,6 +78,13 @@ const TUNING_DEFAULTS = {
   tonalBias: 0.15,
   bassBonus: 0.3,
   useBassChroma: false,
+  bassConfidenceThreshold: 0.25,
+  tempoRegionThreshold: 0.20,
+  rmsSilenceThreshold: 0.005,
+  trailingSilenceWindowS: 3.0,
+  trailingSilenceRatio: 0.10,
+  mergeSameRoot: true,
+  maxMergeDurationS: 4.0,
 } as const;
 
 // IMPORTANT: keep these in sync with src/harmonic_analysis/audio/_key_ensemble.py
@@ -121,9 +154,17 @@ const UploadCard = ({
     segStart: 0,
     segEnd: 0,
     weights: { ...DEFAULT_WEIGHTS },
+    rubato: 'auto',
+    tempoRegionThreshold: null,
     tonalBias: null,
     bassBonus: null,
     useBassChroma: null,
+    bassConfidenceThreshold: null,
+    rmsSilenceThreshold: null,
+    trailingSilenceWindowS: null,
+    trailingSilenceRatio: null,
+    mergeSameRoot: null,
+    maxMergeDurationS: null,
   });
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [audioSrc, setAudioSrc] = useState<string | null>(null);
@@ -154,9 +195,17 @@ const UploadCard = ({
       showDetails: config.showDetails,
       preset: config.preset,
       weights: weightsTouched ? config.weights : undefined,
+      rubato: config.rubato,
+      tempoRegionThreshold: config.tempoRegionThreshold ?? undefined,
       tonalBias: config.tonalBias ?? undefined,
       bassBonus: config.bassBonus ?? undefined,
       useBassChroma: config.useBassChroma ?? undefined,
+      bassConfidenceThreshold: config.bassConfidenceThreshold ?? undefined,
+      rmsSilenceThreshold: config.rmsSilenceThreshold ?? undefined,
+      trailingSilenceWindowS: config.trailingSilenceWindowS ?? undefined,
+      trailingSilenceRatio: config.trailingSilenceRatio ?? undefined,
+      mergeSameRoot: config.mergeSameRoot ?? undefined,
+      maxMergeDurationS: config.maxMergeDurationS ?? undefined,
       runPatternAnalysis: config.runPatternAnalysis,
     });
   };
@@ -165,9 +214,17 @@ const UploadCard = ({
     setConfig((c) => ({
       ...c,
       weights: { ...DEFAULT_WEIGHTS },
+      rubato: 'auto',
+      tempoRegionThreshold: null,
       tonalBias: null,
       bassBonus: null,
       useBassChroma: null,
+      bassConfidenceThreshold: null,
+      rmsSilenceThreshold: null,
+      trailingSilenceWindowS: null,
+      trailingSilenceRatio: null,
+      mergeSameRoot: null,
+      maxMergeDurationS: null,
     }));
   };
 
@@ -462,18 +519,78 @@ const UploadCard = ({
                 })}
               </div>
 
-              {/* Chord-estimation tuning: separate from the ensemble-vote
-                  weights above. These shape how the chord-recognition
-                  template-matcher behaves, not how key votes get tallied. */}
+              {/* Below the ensemble-vote weights, the chord-estimation
+                  pipeline is broken into four logical sub-groups. Order
+                  follows the pipeline phases the parameters affect, top
+                  to bottom: timing → matching → consolidation → silence
+                  gates. Most users only ever touch the timing section. */}
+
+              {/* ── Timing & tempo ─────────────────────────────────── */}
               <div className="border-t border-slate-200 pt-3 space-y-3">
                 <div>
                   <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500 mb-1">
-                    Chord estimation
+                    Timing &amp; tempo
                   </div>
                   <p className="text-[11px] text-slate-600 leading-relaxed">
-                    Shapes the chord-recognition template matcher rather than the key vote.
-                    Most users never need these — defaults are calibrated for general-purpose
-                    pop / rock / classical material.
+                    How wide the chord-recognition window is and how the
+                    tempo-region detector splits sections.
+                  </p>
+                </div>
+
+                <div className="space-y-1.5">
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-sm font-medium text-slate-700">rubato</span>
+                    <span className="text-[10px] font-mono text-slate-400">default auto</span>
+                  </div>
+                  <p className="text-[11px] text-slate-500 leading-relaxed">
+                    Chord-window timing.{' '}
+                    <strong className="text-slate-700">auto</strong> detects the BPM and
+                    sizes the window to ~2 beats. Move toward{' '}
+                    <strong className="text-slate-700">strict</strong> for fast chord
+                    changes; toward <strong className="text-slate-700">loose</strong>/
+                    <strong className="text-slate-700">free</strong> if chord events look
+                    over-fragmented (slow ballads, busy figuration).
+                  </p>
+                  <select
+                    value={config.rubato}
+                    onChange={(e) =>
+                      setConfig((c) => ({ ...c, rubato: e.target.value as RubatoPreset }))
+                    }
+                    className="w-full rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm focus:border-primary-500 focus:ring-1 focus:ring-primary-500"
+                  >
+                    <option value="auto">auto — detect tempo, size dynamically</option>
+                    <option value="strict">strict — 0.25s window (fast changes)</option>
+                    <option value="moderate">moderate — 0.5s window</option>
+                    <option value="loose">loose — 0.75s window (smoother)</option>
+                    <option value="free">free — 1.0s window (very smooth)</option>
+                  </select>
+                </div>
+
+                <SliderRow
+                  label="tempo_region_threshold"
+                  title="Tempo-region sensitivity"
+                  description="Fractional BPM divergence above which auto-rubato emits a separate region. Lower (0.10) over-segments on performance jitter; higher (0.30) misses real tempo changes. Only effective when rubato='auto'."
+                  value={config.tempoRegionThreshold ?? TUNING_DEFAULTS.tempoRegionThreshold}
+                  defaultValue={TUNING_DEFAULTS.tempoRegionThreshold}
+                  isDefault={config.tempoRegionThreshold === null}
+                  min={0.05}
+                  max={0.50}
+                  step={0.01}
+                  onChange={(v) => setConfig((c) => ({ ...c, tempoRegionThreshold: v }))}
+                  disabled={config.rubato !== 'auto'}
+                  disabledHint="Set rubato='auto' to use this."
+                />
+              </div>
+
+              {/* ── Chord matching ─────────────────────────────────── */}
+              <div className="border-t border-slate-200 pt-3 space-y-3">
+                <div>
+                  <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500 mb-1">
+                    Chord matching
+                  </div>
+                  <p className="text-[11px] text-slate-600 leading-relaxed">
+                    How the template-matcher weighs candidates. Defaults are calibrated for
+                    general-purpose pop / rock / classical material.
                   </p>
                 </div>
 
@@ -488,21 +605,6 @@ const UploadCard = ({
                   max={0.5}
                   step={0.01}
                   onChange={(v) => setConfig((c) => ({ ...c, tonalBias: v }))}
-                />
-
-                <SliderRow
-                  label="bass_bonus"
-                  title="Bass-root bonus"
-                  description="When bass-chroma is on, this is the extra score the chord matcher gives templates whose root matches the bass note. Higher = bass tells you the chord; lower = treat the bass as one voice among many."
-                  value={config.bassBonus ?? TUNING_DEFAULTS.bassBonus}
-                  defaultValue={TUNING_DEFAULTS.bassBonus}
-                  isDefault={config.bassBonus === null}
-                  min={0}
-                  max={1}
-                  step={0.05}
-                  onChange={(v) => setConfig((c) => ({ ...c, bassBonus: v }))}
-                  disabled={config.useBassChroma === false}
-                  disabledHint="Enable bass-chroma below to use this."
                 />
 
                 <label className="flex items-start gap-2 cursor-pointer select-none">
@@ -527,23 +629,169 @@ const UploadCard = ({
                     </p>
                   </div>
                 </label>
+
+                <SliderRow
+                  label="bass_bonus"
+                  title="Bass-root bonus"
+                  description="When bass-chroma is on, this is the extra score chord templates whose root matches the bass note receive. Higher = bass tells you the chord; lower = treat the bass as one voice among many."
+                  value={config.bassBonus ?? TUNING_DEFAULTS.bassBonus}
+                  defaultValue={TUNING_DEFAULTS.bassBonus}
+                  isDefault={config.bassBonus === null}
+                  min={0}
+                  max={1}
+                  step={0.05}
+                  onChange={(v) => setConfig((c) => ({ ...c, bassBonus: v }))}
+                  disabled={config.useBassChroma !== true}
+                  disabledHint="Enable bass-chroma above to use this."
+                />
+
+                <SliderRow
+                  label="bass_confidence_threshold"
+                  title="Bass-bonus gating"
+                  description="Minimum bass-chroma 'peakiness' (max-PC vs mean) for the bonus to fire. Higher restricts the bonus to very clear bass signals; lower lets it fire on noisier basslines."
+                  value={config.bassConfidenceThreshold ?? TUNING_DEFAULTS.bassConfidenceThreshold}
+                  defaultValue={TUNING_DEFAULTS.bassConfidenceThreshold}
+                  isDefault={config.bassConfidenceThreshold === null}
+                  min={0}
+                  max={1}
+                  step={0.05}
+                  onChange={(v) => setConfig((c) => ({ ...c, bassConfidenceThreshold: v }))}
+                  disabled={config.useBassChroma !== true}
+                  disabledHint="Enable bass-chroma above to use this."
+                />
+              </div>
+
+              {/* ── Chord consolidation ────────────────────────────── */}
+              <div className="border-t border-slate-200 pt-3 space-y-3">
+                <div>
+                  <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500 mb-1">
+                    Chord consolidation
+                  </div>
+                  <p className="text-[11px] text-slate-600 leading-relaxed">
+                    Post-processing that fuses ping-pong chord events sharing the same root.
+                  </p>
+                </div>
+
+                <label className="flex items-start gap-2 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={config.mergeSameRoot ?? TUNING_DEFAULTS.mergeSameRoot}
+                    onChange={(e) =>
+                      setConfig((c) => ({ ...c, mergeSameRoot: e.target.checked }))
+                    }
+                    className="h-4 w-4 mt-0.5 text-primary-600 focus:ring-primary-500 border-slate-300 rounded"
+                  />
+                  <div className="flex-1">
+                    <div className="text-sm text-slate-700">
+                      merge_same_root{' '}
+                      <span className="text-[10px] font-mono text-slate-400">
+                        default {TUNING_DEFAULTS.mergeSameRoot ? 'on' : 'off'}
+                      </span>
+                    </div>
+                    <p className="text-[11px] text-slate-500 leading-relaxed mt-0.5">
+                      Merges adjacent same-root events that disagree on quality (e.g.
+                      Dm7→D7→Dm7 collapses to one). Disable to see raw matcher output.
+                    </p>
+                  </div>
+                </label>
+
+                <SliderRow
+                  label="max_merge_duration_s"
+                  title="Max merge duration"
+                  description="Upper cap (seconds) on a merged event. Real chord changes across bar lines shouldn't fuse just because they share a root. ~1 measure at typical tempos is the sweet spot."
+                  value={config.maxMergeDurationS ?? TUNING_DEFAULTS.maxMergeDurationS}
+                  defaultValue={TUNING_DEFAULTS.maxMergeDurationS}
+                  isDefault={config.maxMergeDurationS === null}
+                  min={0.5}
+                  max={10}
+                  step={0.5}
+                  onChange={(v) => setConfig((c) => ({ ...c, maxMergeDurationS: v }))}
+                  disabled={config.mergeSameRoot === false}
+                  disabledHint="Enable merge_same_root above to use this."
+                />
+              </div>
+
+              {/* ── Silence detection ──────────────────────────────── */}
+              <div className="border-t border-slate-200 pt-3 space-y-3">
+                <div>
+                  <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500 mb-1">
+                    Silence detection
+                  </div>
+                  <p className="text-[11px] text-slate-600 leading-relaxed">
+                    Two stacked gates: an absolute floor (catches true silence) and an
+                    adaptive trailing-window gate (catches fade-outs that are quiet relative
+                    to recent context).
+                  </p>
+                </div>
+
+                <SliderRow
+                  label="rms_silence_threshold"
+                  title="Absolute silence floor"
+                  description="Windows whose mean RMS amplitude falls below this are skipped. 0.005 ≈ -46 dBFS — drops noise floor without biting into pp passages."
+                  value={config.rmsSilenceThreshold ?? TUNING_DEFAULTS.rmsSilenceThreshold}
+                  defaultValue={TUNING_DEFAULTS.rmsSilenceThreshold}
+                  isDefault={config.rmsSilenceThreshold === null}
+                  min={0}
+                  max={0.05}
+                  step={0.001}
+                  onChange={(v) => setConfig((c) => ({ ...c, rmsSilenceThreshold: v }))}
+                />
+
+                <SliderRow
+                  label="trailing_silence_window_s"
+                  title="Trailing-window length"
+                  description="How far back the adaptive gate looks to compute recent loudness. 3-5s is the sweet spot — long enough for stability, short enough to react to fade-outs."
+                  value={config.trailingSilenceWindowS ?? TUNING_DEFAULTS.trailingSilenceWindowS}
+                  defaultValue={TUNING_DEFAULTS.trailingSilenceWindowS}
+                  isDefault={config.trailingSilenceWindowS === null}
+                  min={0}
+                  max={10}
+                  step={0.5}
+                  onChange={(v) => setConfig((c) => ({ ...c, trailingSilenceWindowS: v }))}
+                />
+
+                <SliderRow
+                  label="trailing_silence_ratio"
+                  title="Adaptive gate ratio"
+                  description="Threshold as a fraction of trailing-window mean RMS. 0.10 = 'current window must be more than 20 dB below recent average to trip the gate'. Set to 0 to disable adaptive gating."
+                  value={config.trailingSilenceRatio ?? TUNING_DEFAULTS.trailingSilenceRatio}
+                  defaultValue={TUNING_DEFAULTS.trailingSilenceRatio}
+                  isDefault={config.trailingSilenceRatio === null}
+                  min={0}
+                  max={0.5}
+                  step={0.01}
+                  onChange={(v) => setConfig((c) => ({ ...c, trailingSilenceRatio: v }))}
+                  disabled={
+                    (config.trailingSilenceWindowS ?? TUNING_DEFAULTS.trailingSilenceWindowS) ===
+                    0
+                  }
+                  disabledHint="Trailing-window length is 0 — adaptive gate is off."
+                />
               </div>
 
               <div className="flex items-center justify-between gap-3 border-t border-slate-200 pt-2.5">
                 <div className="text-[11px] text-slate-500 leading-relaxed">
                   <strong className="text-slate-700">Tuning tips:</strong> set a weight to{' '}
-                  <span className="font-mono">0</span> to disable an approach entirely. Numbers
-                  above <span className="font-mono">1</span> amplify its contribution. Changes
-                  only take effect on the next analyze.
+                  <span className="font-mono">0</span> to disable an approach entirely.
+                  Numbers above <span className="font-mono">1</span> amplify its
+                  contribution. Changes only take effect on the next analyze.
                 </div>
                 <button
                   type="button"
                   onClick={resetWeights}
                   disabled={
                     weightsAreDefault(config.weights) &&
+                    config.rubato === 'auto' &&
+                    config.tempoRegionThreshold === null &&
                     config.tonalBias === null &&
                     config.bassBonus === null &&
-                    config.useBassChroma === null
+                    config.useBassChroma === null &&
+                    config.bassConfidenceThreshold === null &&
+                    config.rmsSilenceThreshold === null &&
+                    config.trailingSilenceWindowS === null &&
+                    config.trailingSilenceRatio === null &&
+                    config.mergeSameRoot === null &&
+                    config.maxMergeDurationS === null
                   }
                   className="text-xs font-medium text-primary-700 hover:text-primary-900 disabled:text-slate-400 disabled:cursor-not-allowed whitespace-nowrap"
                 >

--- a/demo/frontend/src/types/audio.ts
+++ b/demo/frontend/src/types/audio.ts
@@ -34,6 +34,23 @@ export interface AudioSegment {
   end: number;
 }
 
+// Tempo metadata — populated when rubato="auto" triggered detection.
+// `regions` is empty for stable-tempo material; multiple entries appear
+// when the music has sustained tempo changes (e.g., accelerando section
+// breaks).
+export interface AudioTempoRegion {
+  start_time: number;
+  end_time: number;
+  bpm: number;
+  confidence: number;
+}
+
+export interface AudioTempo {
+  bpm: number;
+  confidence: number;
+  regions: AudioTempoRegion[];
+}
+
 // Diagnostic panel — only populated when show_details=true was sent.
 export interface KeyApproachCandidate {
   key: AudioGlobalKey;
@@ -68,6 +85,7 @@ export interface AudioAnalysisResponse {
   analysis: AudioCadenceSummary;
   chord_progression: AudioChordEvent[];
   segment: AudioSegment;
+  tempo?: AudioTempo;
   key_analysis_details?: KeyAnalysisDetails;
 }
 
@@ -112,6 +130,9 @@ export interface EnrichedAudioResult {
   };
   chord_progression: EnrichedChordEvent[];
   segment: AudioSegment;
+  /** Tempo info from auto-rubato detection. `undefined` when the caller
+   *  used a static rubato preset (no detection performed). */
+  tempo?: AudioTempo;
   /** When global tonic+mode == local tonic+mode (modulo enharmonic), the
    *  region card calls out "same notes, different tonal center". */
   keysMatch: boolean;
@@ -122,6 +143,7 @@ export interface EnrichedAudioResult {
 
 // ── Audio analyze request options ───────────────────────────────────────────
 export type KeyDetectionPreset = 'default' | 'ks_only' | 'full';
+export type RubatoPreset = 'auto' | 'strict' | 'moderate' | 'loose' | 'free';
 
 export interface AnalyzeAudioOptions {
   start?: number;       // segment start in seconds
@@ -130,6 +152,19 @@ export interface AnalyzeAudioOptions {
   preset?: KeyDetectionPreset;
   /** Optional weight overrides per approach name. */
   weights?: Record<string, number>;
+
+  // ── Timing & tempo ──────────────────────────────────────────────────
+  /** Chord-window timing preset. `"auto"` (default in the demo) detects BPM
+   *  and sizes the analysis window dynamically. Static presets override auto.
+   *  A number 0.0–1.0 interpolates between strict and free. */
+  rubato?: RubatoPreset | number;
+  /** Fractional BPM change above which auto-rubato emits a separate tempo
+   *  region. Library default 0.20 (= 20%). Lower values over-segment;
+   *  higher values miss real tempo changes. Only effective when
+   *  `rubato="auto"`. */
+  tempoRegionThreshold?: number;
+
+  // ── Chord matching ──────────────────────────────────────────────────
   /** Diatonic similarity bonus for chord estimation. Library default 0.15.
    *  Higher values bias chord matching toward in-key chords. */
   tonalBias?: number;
@@ -139,6 +174,33 @@ export interface AnalyzeAudioOptions {
   /** When true, the chord estimator extracts a bass-register chroma layer to
    *  disambiguate roots (Am vs C, Bm vs D). Library default false. */
   useBassChroma?: boolean;
+  /** Minimum bass-chroma peakiness for the bass-bonus to fire. Library
+   *  default 0.25. Higher values restrict the bonus to very clear bass
+   *  signals. Only meaningful when useBassChroma is on. */
+  bassConfidenceThreshold?: number;
+
+  // ── Silence detection ───────────────────────────────────────────────
+  /** Absolute RMS amplitude floor below which a window is treated as
+   *  silence. Library default 0.005 (~-46 dBFS). */
+  rmsSilenceThreshold?: number;
+  /** Length in seconds of the trailing window the adaptive (envelope-
+   *  relative) silence gate uses for context. Library default 3.0s.
+   *  Set to 0 to disable adaptive gating. */
+  trailingSilenceWindowS?: number;
+  /** Threshold for the adaptive gate as a fraction of trailing-window mean
+   *  RMS. Library default 0.10 (current window must be >10% of recent
+   *  loudness, ~20 dB drop). Set to 0 to disable. */
+  trailingSilenceRatio?: number;
+
+  // ── Chord consolidation ─────────────────────────────────────────────
+  /** When true (default), adjacent same-root chord events with different
+   *  qualities are merged into one. Disable to see the raw matcher output. */
+  mergeSameRoot?: boolean;
+  /** Upper cap (seconds) on a merged chord event's duration. Real chord
+   *  changes across bar lines shouldn't fuse just because they share a
+   *  root. Library default 4.0s (≈ one measure at typical tempos). */
+  maxMergeDurationS?: number;
+
   /** When true, the demo also runs the extracted chord labels through the
    *  library's pattern analysis (the same engine Manual entry uses) and
    *  renders the full Roman / cadence / pattern result tree. */

--- a/demo/frontend/src/utils/audioAdapter.ts
+++ b/demo/frontend/src/utils/audioAdapter.ts
@@ -195,6 +195,7 @@ export const enrichAudioResult = (response: AudioAnalysisResponse): EnrichedAudi
     },
     chord_progression,
     segment: response.segment,
+    tempo: response.tempo,
     keysMatch,
     borrowedLabels,
   };

--- a/src/harmonic_analysis/audio/_chord_estimation.py
+++ b/src/harmonic_analysis/audio/_chord_estimation.py
@@ -122,6 +122,35 @@ _TEMPLATE_MATRIX: np.ndarray = np.array(
 )
 
 
+def _trailing_mean(arr: np.ndarray, window: int) -> np.ndarray:
+    """Trailing-window mean at every index using cumulative sums.
+
+    For index ``i``, returns ``mean(arr[max(0, i - window + 1) : i + 1])``
+    — the average over the preceding ``window`` samples (inclusive of
+    ``i``). Used by the adaptive (envelope-relative) silence gate so
+    each chord-estimation window can compare its own energy to recent
+    context without recomputing the average per window.
+
+    O(n) via cumulative sum. Reflects no-history correctly: index 0's
+    "trailing mean" is just ``arr[0]``, not zero.
+    """
+    n = arr.size
+    if n == 0:
+        return arr.copy().astype(np.float64)
+    w = max(1, window)
+    if w >= n:
+        # Window covers everything — every index gets the prefix mean.
+        csum = np.cumsum(arr.astype(np.float64))
+        counts = np.arange(1, n + 1, dtype=np.float64)
+        return csum / counts
+    csum = np.concatenate([[0.0], np.cumsum(arr.astype(np.float64))])
+    out = np.empty(n, dtype=np.float64)
+    for i in range(n):
+        start = max(0, i - w + 1)
+        out[i] = (csum[i + 1] - csum[start]) / (i + 1 - start)
+    return out
+
+
 def _root_pitch_class(label: str) -> int:
     """Extract the root pitch class (0-11) from a chord label.
 
@@ -158,6 +187,8 @@ def estimate_chord_progression(
     min_chroma_norm: float = 0.05,
     rms_frames: Optional[np.ndarray] = None,
     rms_silence_threshold: float = 0.005,
+    trailing_silence_window_s: float = 3.0,
+    trailing_silence_ratio: float = 0.10,
     median_kernel: int = 3,
     merge_same_root: bool = True,
     max_merge_duration_s: float = 4.0,
@@ -212,13 +243,34 @@ def estimate_chord_progression(
             ``rms_silence_threshold`` are skipped entirely — closes
             the silent-tail hole that ``min_chroma_norm`` can't.
             Use ``extract_local_rms_envelope`` to build it.
-        rms_silence_threshold: Mean RMS amplitude below which a window
+        rms_silence_threshold: Absolute RMS floor below which a window
             is treated as silence (only effective when ``rms_frames``
             is supplied). 0.005 ≈ -46 dBFS — drops the decay tail and
             room-noise floor on typical classical recordings without
             biting into pp passages. Raise to 0.01 (~-40 dBFS) for
             heavily compressed pop, lower to 0.002 (~-54 dBFS) if the
-            recording's dynamic range demands it.
+            recording's dynamic range demands it. Pair with the
+            trailing-window gate below for fade-out detection.
+        trailing_silence_window_s: Length in seconds of the trailing
+            window used by the adaptive (envelope-relative) gate. The
+            gate compares each window's RMS to the mean RMS over the
+            preceding ``trailing_silence_window_s`` seconds — when the
+            current window is much quieter than recent context, it's
+            treated as silence regardless of the absolute floor. 3.0s
+            is the sweet spot for typical pop / classical: long enough
+            to average across a few measures, short enough to react to
+            actual fade-outs within a few seconds. Set to 0.0 to
+            disable adaptive gating (only the absolute floor remains).
+        trailing_silence_ratio: Threshold for the adaptive gate as a
+            fraction of trailing-window mean RMS. A window is gated
+            when ``window_rms < trailing_avg * trailing_silence_ratio``.
+            0.10 = "current window is more than 20 dB below the recent
+            average" — catches fade-out tails that the absolute floor
+            misses, without biting into legitimate quiet passages
+            (which usually sit only 6–15 dB below their context).
+            Lower values (0.05) are stricter; higher values (0.20)
+            cut more aggressively. Set to 0.0 to disable the adaptive
+            gate.
         median_kernel: Kernel size for running-median smoothing over
             raw chord labels. Must be odd and >= 1. Larger values
             produce smoother (but laggier) chord sequences. Default
@@ -313,6 +365,24 @@ def estimate_chord_progression(
     # ignore the gate than mask the wrong windows.
     use_rms_gate = rms_frames is not None and rms_frames.shape == (T,)
 
+    # Adaptive (envelope-relative) gate: pre-compute a trailing-window
+    # mean RMS at every frame so the per-window check below is O(1).
+    # Catches fade-outs that are quiet relative to recent context but
+    # still above the absolute floor — a song mixed at -10 dBFS whose
+    # fade-out drops to -35 dBFS won't trip the static silence threshold
+    # (-46 dBFS), but it IS clearly quieter than recent music. Disabled
+    # when use_rms_gate is off (no RMS to average) or when the trailing
+    # window/ratio params are zeroed (caller opted out).
+    use_trailing_gate = (
+        use_rms_gate and trailing_silence_window_s > 0 and trailing_silence_ratio > 0
+    )
+    trailing_rms_arr: Optional[np.ndarray] = None
+    if use_trailing_gate:
+        assert rms_frames is not None  # mypy hint
+        trailing_rms_arr = _trailing_mean(
+            rms_frames, int(trailing_silence_window_s * frames_per_sec)
+        )
+
     # --- Sliding window similarity ---
     num_windows = 1 + (T - win_frames) // hop_frames
     raw_labels: List[int] = []  # index into _TEMPLATE_LABELS
@@ -338,12 +408,30 @@ def estimate_chord_progression(
 
         # RMS gate first — cheaper than norm + tells us about audio
         # energy, not about whatever shape librosa's normalization
-        # squeezed the chroma into.
+        # squeezed the chroma into. Two thresholds:
+        #   1. Absolute floor (rms_silence_threshold) — catches true
+        #      silence and noise floor.
+        #   2. Adaptive (envelope-relative) — current window must be
+        #      at least trailing_silence_ratio of the trailing average,
+        #      otherwise the chord matcher is averaging across a fade
+        #      where chroma_cqt produces meaningless output.
         if use_rms_gate:
             assert rms_frames is not None  # mypy hint; use_rms_gate implies this
             window_rms = float(rms_frames[start:end].mean())
             if window_rms < rms_silence_threshold:
                 continue
+            if use_trailing_gate:
+                assert trailing_rms_arr is not None  # mypy hint
+                # Reference at the *start* of the window — the trailing
+                # average leading INTO the current window, not including
+                # the current window's own (possibly fading) energy.
+                ref_idx = max(0, start - 1)
+                trailing_avg = float(trailing_rms_arr[ref_idx])
+                if (
+                    trailing_avg > 0
+                    and window_rms < trailing_avg * trailing_silence_ratio
+                ):
+                    continue
 
         # L2-normalize. If the window is silent (norm below threshold),
         # skip it entirely — no point asking "which chord is this silence?"

--- a/src/harmonic_analysis/audio/_key_approaches/cadential.py
+++ b/src/harmonic_analysis/audio/_key_approaches/cadential.py
@@ -156,31 +156,39 @@ class CadentialApproach(KeyDetectionApproach):
             a_pc, a_minor = a
             b_pc, _b_minor = b  # b's quality intentionally ignored — see below
 
-            # 'a' must be a major triad to function as a dominant.
-            # The chord estimator only outputs major/minor triads; minor
-            # dominants are theoretically possible but vanishingly rare
-            # in tonal repertoire and we don't credit them here.
-            if a_minor:
-                continue
-
-            # Walk all 12 tonic candidates; credit equally for both
-            # Ionian and Aeolian when a is the dominant of tonic_pc and
-            # b lands on tonic_pc (regardless of b's quality).
+            # Walk all 12 tonic candidates; credit when a is a fifth
+            # above b (the V→I dominant relationship). The credit
+            # depends on whether a is major or minor:
+            #
+            # - **Major V → I/i** (e.g., F#→Bm or F#→B): canonical
+            #   tonal cadence. Credit BOTH Ionian and Aeolian of the
+            #   tonic equally — a single major-V cadence doesn't
+            #   distinguish parallel modes (B major vs B minor with
+            #   raised leading tone), so let the rest of the ensemble
+            #   vote on mode.
+            #
+            # - **Minor v → i** (e.g., F#m→Bm): the natural-minor /
+            #   Aeolian cadence. Credit ONLY Aeolian of the tonic. A
+            #   minor v specifically rules out the major-mode reading
+            #   (Ionian's V is always major), so it's a strong Aeolian
+            #   signal. Without this case, modal songs that don't
+            #   raise the leading tone (most rock, folk, and a lot of
+            #   contemporary pop) get no cadential credit and lose
+            #   their tonic to whichever relative-major sibling
+            #   happens to share chord transitions.
             for tonic_pc in range(12):
                 expected_dominant_pc = (tonic_pc + 7) % 12
                 if a_pc != expected_dominant_pc or b_pc != tonic_pc:
                     continue
 
-                # Mode-agnostic dual credit. Both Ionian and Aeolian of
-                # the same tonic root get +1 because cadential can't
-                # (and shouldn't) tell parallel-mode apart from a single
-                # V → tonic motion. F#→Bm is a minor authentic cadence;
-                # F#→B is a major authentic cadence; the chord-after-
-                # the-V information alone doesn't distinguish "the piece
-                # is in B" from "the piece is in B major vs B minor."
-                # Let the rest of the ensemble vote on mode.
-                cadence_counts[tonic_pc * 2] += 1  # Ionian slot
-                cadence_counts[tonic_pc * 2 + 1] += 1  # Aeolian slot
+                if a_minor:
+                    # Minor v → i: Aeolian-only credit.
+                    cadence_counts[tonic_pc * 2 + 1] += 1
+                else:
+                    # Major V → I/i: dual credit, modes argued out
+                    # downstream.
+                    cadence_counts[tonic_pc * 2] += 1  # Ionian slot
+                    cadence_counts[tonic_pc * 2 + 1] += 1  # Aeolian slot
 
         max_count = max(cadence_counts)
         if max_count == 0:

--- a/src/harmonic_analysis/audio/_tempo.py
+++ b/src/harmonic_analysis/audio/_tempo.py
@@ -159,22 +159,105 @@ def detect_tempo(
     if tempo_array is None or tempo_array.size == 0:
         return TempoInfo(bpm=0.0, confidence=0.0)
 
-    bpm = float(np.median(tempo_array))
-    # Confidence is 1 minus normalized std. Std of 30 BPM is roughly
-    # "completely free tempo" → confidence 0; std of 0 is rock-steady → 1.
-    std = float(tempo_array.std())
+    # Two-step preprocessing before scoring. librosa's onset tempogram
+    # has two well-known failure modes on pop/electronic material:
+    #
+    # 1. **Octave errors** — different sections lock onto different
+    #    musical multiples of the same beat (e.g., 84 / 112 / 172 BPM
+    #    for the same song). All multiples of each other, but the std
+    #    spikes and the confidence collapses. Fold all values into a
+    #    one-octave canonical range so doubles/halves merge.
+    # 2. **Per-frame jitter** — even within one section, individual
+    #    frames flip between adjacent multiples. A moving median
+    #    suppresses single-frame spikes without smearing real changes.
+    #
+    # Order matters: fold first (so smoothing operates on the canonical
+    # values), then smooth.
+    folded = _fold_octaves(tempo_array)
+    smoothed = _moving_median(folded, kernel_size=43)  # ~0.5s @ 86 fps
+
+    bpm = float(np.median(smoothed))
+    # Confidence is 1 minus normalized std on the *smoothed-and-folded*
+    # curve. Std of 30 BPM is roughly "completely free tempo" →
+    # confidence 0; std of 0 is rock-steady → 1.
+    std = float(smoothed.std())
     confidence = max(0.0, min(1.0, 1.0 - std / 30.0))
 
     regions: List[TempoRegion] = []
-    if detect_regions and tempo_array.size > 1 and confidence > 0.0:
+    if detect_regions and smoothed.size > 1 and confidence > 0.0:
         regions = _segment_tempo(
-            tempo_array,
+            smoothed,
             sr=sr,
             segment_start=float(start_time),
             change_threshold=region_change_threshold,
         )
 
     return TempoInfo(bpm=bpm, confidence=confidence, regions=regions)
+
+
+def _fold_octaves(
+    arr: np.ndarray,
+    low: float = 70.0,
+    high: float = 140.0,
+) -> np.ndarray:
+    """Fold tempo values into a one-octave canonical range.
+
+    Iteratively halves anything above ``high`` and doubles anything
+    below ``low`` until every value sits in ``[low, high]``. The
+    default range ``[70, 140]`` is a perfect octave (140 = 2×70) that
+    spans most musical tempi without splitting any common pop or
+    classical tempo across the boundary.
+
+    Why this matters: librosa's per-frame tempo can lock onto different
+    musical multiples of the same beat in different sections of a song
+    (e.g., 84 in the verse, 168 in the chorus, 112 elsewhere — all the
+    same underlying tempo, just different beat subdivisions). Without
+    folding, the std looks huge and the confidence score collapses.
+    With folding, those values collapse to ~84 / ~84 / ~112 — much
+    tighter, and confidence reflects actual stability.
+
+    The fold preserves real tempo *changes* within the canonical range
+    — a song that genuinely shifts from 95 to 130 BPM still shows that
+    shift after folding.
+    """
+    if arr.size == 0:
+        return arr.copy()
+    out = arr.astype(np.float64).copy()
+    # Bound the loops defensively in case low/high are degenerate.
+    if high <= low or low <= 0:
+        return out
+    # Halve until in range.
+    for _ in range(10):  # 10 octaves covers any realistic input
+        mask = out > high
+        if not np.any(mask):
+            break
+        out[mask] = out[mask] / 2.0
+    # Double until in range.
+    for _ in range(10):
+        mask = out < low
+        if not np.any(mask):
+            break
+        out[mask] = out[mask] * 2.0
+    return out
+
+
+def _moving_median(arr: np.ndarray, kernel_size: int) -> np.ndarray:
+    """Running-median filter over a 1D array, reflecting at edges.
+
+    Used to suppress octave-error spikes in librosa's per-frame tempo
+    curve before std/segmentation. Pure numpy, no scipy. Kernel must
+    be odd; if it isn't, we round up.
+    """
+    if arr.size <= 1 or kernel_size <= 1:
+        return arr.copy()
+    if kernel_size % 2 == 0:
+        kernel_size += 1
+    pad = kernel_size // 2
+    padded = np.pad(arr, pad, mode="reflect")
+    out = np.empty_like(arr, dtype=np.float64)
+    for i in range(arr.size):
+        out[i] = np.median(padded[i : i + kernel_size])
+    return out
 
 
 def _segment_tempo(
@@ -184,6 +267,7 @@ def _segment_tempo(
     segment_start: float,
     change_threshold: float,
     min_region_s: float = 4.0,
+    region_merge_threshold: Optional[float] = None,
 ) -> List[TempoRegion]:
     """Split a per-frame tempo curve into constant-BPM regions.
 
@@ -200,10 +284,24 @@ def _segment_tempo(
         sr: Sample rate of the original audio (for time conversion).
         segment_start: Audio time (seconds) corresponding to the first
             element of ``tempo_array``.
-        change_threshold: Fractional change that triggers a new region.
+        change_threshold: Fractional per-frame divergence from the
+            running region mean that triggers a pass-1 split. Tighter
+            values (0.10) over-segment on performance jitter, looser
+            (0.30) miss real changes.
         min_region_s: Regions shorter than this are merged into the
             longer neighbor. 4 seconds catches single-bar wobble in
             most popular tempos.
+        region_merge_threshold: Pass-3 inter-region mean divergence
+            below which adjacent regions collapse back into one. Should
+            be slightly more lenient than ``change_threshold`` because
+            pass 1 detects single-frame outliers while pass 3 evaluates
+            sustained means — a region with mean 20.5% off its neighbor
+            can be the same musical idea with one outlier frame, but a
+            single frame at 20.5% definitely deserves a new region.
+            Defaults to ``change_threshold + 0.02`` (so 0.20 → 0.22)
+            which empirically resolves Bach's ritardando-at-end (~20.5%
+            inter-region diff, should merge) without losing genuine
+            section-level tempo bumps (typically 22%+).
 
     Returns:
         List of ``TempoRegion`` covering the full duration. Always at
@@ -212,6 +310,12 @@ def _segment_tempo(
     # librosa.feature.tempo's frame rate matches its onset envelope —
     # default hop_length=512 → frames_per_sec = sr/512.
     fps = sr / 512.0
+
+    # Pass 3's threshold defaults to slightly more lenient than pass 1's.
+    # See the docstring for the full rationale; in short: per-frame
+    # outliers shouldn't survive into the final region list.
+    if region_merge_threshold is None:
+        region_merge_threshold = change_threshold + 0.02
 
     # First pass: split on any frame where the current frame deviates
     # from the running region mean by more than the threshold.
@@ -269,6 +373,32 @@ def _segment_tempo(
         else:
             cleaned.append((start, end, mean))
 
+    # Third pass: merge adjacent regions whose means are within wobble
+    # range of each other. Pass 1 starts a new region on a *single*
+    # outlier frame even when the long-run mean stays similar (one
+    # missed onset, librosa double-counting a syncopation, a single
+    # rushed bar). Pass 2 catches the cases where one of the two
+    # neighbors is short. But neighbors that both clear ``min_region_s``
+    # with similar means still escape — a region split should require
+    # a *sustained* tempo change, not a momentary wobble.
+    if len(cleaned) > 1:
+        coalesced: List[tuple[int, int, float]] = [cleaned[0]]
+        for start, end, mean in cleaned[1:]:
+            prev_start, prev_end, prev_mean = coalesced[-1]
+            if prev_mean <= 0:
+                coalesced[-1] = (prev_start, end, mean)
+                continue
+            mean_diff = abs(mean - prev_mean) / prev_mean
+            if mean_diff <= region_merge_threshold:
+                prev_len = prev_end - prev_start
+                curr_len = end - start
+                new_len = prev_len + curr_len
+                new_mean = (prev_mean * prev_len + mean * curr_len) / new_len
+                coalesced[-1] = (prev_start, end, new_mean)
+            else:
+                coalesced.append((start, end, mean))
+        cleaned = coalesced
+
     # Convert frames to seconds and compute per-region confidence.
     out: List[TempoRegion] = []
     for start_f, end_f, mean_bpm in cleaned:
@@ -318,11 +448,27 @@ def bpm_to_rubato(
         as the static rubato presets in ``_profiles.py``.
     """
     if confidence < _MIN_TEMPO_CONFIDENCE or bpm <= 0:
-        # Moderate fallback — same numbers as the static preset.
-        return (0.5, 0.25, 3)
+        # Loose fallback — same numbers as the "loose" static preset.
+        # Material that defeats BPM detection (heavy reverb, free tempo,
+        # busy electronic production) is exactly the material that
+        # produces the most chord-event fragmentation under moderate's
+        # 0.5s window. Loose's 0.75s window + kernel=5 absorbs the
+        # ambiguity better. If the caller wants tight grids despite
+        # detection failure, they can pass an explicit static preset.
+        return (0.75, 0.4, 5)
 
+    # Cap the auto-window at 1.0s. Two beats is the right multiplier at
+    # higher detected tempos (where each "beat" is short), but at slower
+    # tempos like 90 BPM it gives a 1.32s window — wide enough to
+    # over-smooth piano music with chord-per-beat harmonic rhythm.
+    # Brief dominant chords (V before i) get averaged into the
+    # surrounding chords, and cadential loses the V→i evidence it
+    # needs to identify the tonic. 1.0s is the empirical sweet spot:
+    # still catches Bach's sixteenth-note figuration (132 BPM detected
+    # → 0.91s, unchanged) but doesn't smear piano transients
+    # (90 BPM → was 1.32s, now capped to 1.0s).
     window_s = 2.0 * (60.0 / bpm)
-    window_s = max(0.4, min(2.0, window_s))
+    window_s = max(0.4, min(1.0, window_s))
     hop_s = window_s / 2.0
     # Larger window → more figuration averaged in → ping-pong is rarer
     # but when it does happen, a wider median window is the right

--- a/src/harmonic_analysis/integrations/audio_adapter.py
+++ b/src/harmonic_analysis/integrations/audio_adapter.py
@@ -271,11 +271,18 @@ class AudioAdapter:
         tonal_bias: float = 0.15,
         use_bass_chroma: bool = False,
         bass_bonus: float = 0.3,
+        bass_confidence_threshold: float = 0.25,
         rubato: Union[str, float] = "moderate",
         min_chroma_norm: float = 0.05,
+        rms_silence_threshold: float = 0.005,
+        trailing_silence_window_s: float = 3.0,
+        trailing_silence_ratio: float = 0.10,
         key_detection: KeyDetectionSpec = _DEFAULT_KEY_DETECTION,
         show_analysis_details: bool = False,
         key_ensemble_weights: Optional[Dict[str, float]] = None,
+        tempo_region_threshold: float = 0.20,
+        merge_same_root: bool = True,
+        max_merge_duration_s: float = 4.0,
     ) -> None:
         """Initialize the adapter.
 
@@ -380,8 +387,19 @@ class AudioAdapter:
         self._tonal_bias = tonal_bias
         self._use_bass_chroma = use_bass_chroma
         self._bass_bonus = bass_bonus
+        self._bass_confidence_threshold = bass_confidence_threshold
         self._median_kernel = rubato_kernel
         self._min_chroma_norm = min_chroma_norm
+        self._rms_silence_threshold = rms_silence_threshold
+        self._trailing_silence_window_s = trailing_silence_window_s
+        self._trailing_silence_ratio = trailing_silence_ratio
+        self._merge_same_root = merge_same_root
+        self._max_merge_duration_s = max_merge_duration_s
+        # Fractional BPM change that triggers a new tempo region during
+        # auto-rubato detection. 20% is loose enough to ignore performance
+        # micro-variation, tight enough to catch deliberate tempo changes
+        # (accelerando, ritardando, sectional speed shifts).
+        self._tempo_region_threshold = tempo_region_threshold
 
         # Resolve key_detection up front. resolve_preset() validates the
         # spec and raises ValueError for bad input — we want the failure
@@ -516,7 +534,15 @@ class AudioAdapter:
         chord_kernel = self._median_kernel
         if self._rubato_setting == "auto" and self._include_chords:
             tempo_info = detect_tempo(
-                filepath, start_time=resolved_start, end_time=resolved_end
+                filepath,
+                start_time=resolved_start,
+                end_time=resolved_end,
+                # Variable-tempo support: ask for region segmentation so
+                # each constant-tempo span can size its own chord window.
+                # Stable-tempo material gets a single region (or none) and
+                # we fall back to global-BPM sizing automatically.
+                detect_regions=True,
+                region_change_threshold=self._tempo_region_threshold,
             )
             # Explicit window/hop pins from the caller still win — auto
             # only fills in slots the caller left open.
@@ -558,20 +584,85 @@ class AudioAdapter:
                 filepath, start_time=resolved_start, end_time=resolved_end
             )
 
-            chords = estimate_chord_progression(
-                local_chroma,
-                ks_key,  # tonal_bias driven by K-S — stage-1 result
-                sr=sr,
-                hop_length=512,
-                window_size_s=chord_window,
-                hop_size_s=chord_hop,
-                tonal_bias=self._tonal_bias,
-                bass_chroma_frames=bass_chroma if self._use_bass_chroma else None,
-                bass_bonus=self._bass_bonus,
-                min_chroma_norm=self._min_chroma_norm,
-                rms_frames=rms_envelope,
-                median_kernel=chord_kernel,
+            # Variable-tempo path: when auto detected multiple tempo
+            # regions AND those regions would actually get different
+            # window sizes from bpm_to_rubato, run chord estimation
+            # independently per region. When all regions would clamp
+            # to the same window (because the cap or floor pins them),
+            # per-region processing adds no benefit — it just slices
+            # the chroma at region boundaries, which introduces
+            # spurious chord events that confuse the cadential vote.
+            # Stable-tempo material and "regions but same window"
+            # material both fall through to the single-pass global path.
+            #
+            # Empirical note: per-region also helps on songs where the
+            # windows are *technically* distinct but very close (e.g.,
+            # dusty_wings with 0.992s vs 1.000s windows). The slicing
+            # itself appears to give the chord matcher beneficial
+            # boundary resets — without it, chord events bleed across
+            # section transitions and confuse the cadential vote. Keep
+            # the per-region path even when the spread looks tiny.
+            from harmonic_analysis.audio._tempo import bpm_to_rubato
+
+            use_per_region = (
+                tempo_info is not None
+                and len(tempo_info.regions) > 1
+                and not self._chord_window_explicit
+                and not self._chord_hop_explicit
             )
+            if use_per_region:
+                assert tempo_info is not None  # mypy hint
+                # Compute per-region window tuples; if they're all
+                # identical, fall through to the global path. (Tiny
+                # numerical differences still count as distinct — see
+                # the empirical note above.)
+                region_windows = {
+                    bpm_to_rubato(r.bpm, r.confidence) for r in tempo_info.regions
+                }
+                if len(region_windows) <= 1:
+                    use_per_region = False
+
+            if use_per_region:
+                assert tempo_info is not None  # mypy hint
+                chords = _estimate_chords_per_region(
+                    local_chroma=local_chroma,
+                    rms_envelope=rms_envelope,
+                    bass_chroma=bass_chroma if self._use_bass_chroma else None,
+                    regions=tempo_info.regions,
+                    segment_start=resolved_start,
+                    ks_key=ks_key,
+                    sr=sr,
+                    tonal_bias=self._tonal_bias,
+                    bass_bonus=self._bass_bonus,
+                    bass_confidence_threshold=self._bass_confidence_threshold,
+                    min_chroma_norm=self._min_chroma_norm,
+                    rms_silence_threshold=self._rms_silence_threshold,
+                    trailing_silence_window_s=self._trailing_silence_window_s,
+                    trailing_silence_ratio=self._trailing_silence_ratio,
+                    merge_same_root=self._merge_same_root,
+                    max_merge_duration_s=self._max_merge_duration_s,
+                )
+            else:
+                chords = estimate_chord_progression(
+                    local_chroma,
+                    ks_key,  # tonal_bias driven by K-S — stage-1 result
+                    sr=sr,
+                    hop_length=512,
+                    window_size_s=chord_window,
+                    hop_size_s=chord_hop,
+                    tonal_bias=self._tonal_bias,
+                    bass_chroma_frames=(bass_chroma if self._use_bass_chroma else None),
+                    bass_bonus=self._bass_bonus,
+                    bass_confidence_threshold=self._bass_confidence_threshold,
+                    min_chroma_norm=self._min_chroma_norm,
+                    rms_frames=rms_envelope,
+                    rms_silence_threshold=self._rms_silence_threshold,
+                    trailing_silence_window_s=self._trailing_silence_window_s,
+                    trailing_silence_ratio=self._trailing_silence_ratio,
+                    median_kernel=chord_kernel,
+                    merge_same_root=self._merge_same_root,
+                    max_merge_duration_s=self._max_merge_duration_s,
+                )
 
         # Step 5 — STAGE 3: full ensemble. Run every enabled approach
         # against a context that now includes chord events from stage 2.
@@ -717,6 +808,114 @@ class AudioAdapter:
         }
 
 
+def _estimate_chords_per_region(
+    *,
+    local_chroma: Any,  # np.ndarray, kept Any to avoid lazy-import dance
+    rms_envelope: Optional[Any],
+    bass_chroma: Optional[Any],
+    regions: list,
+    segment_start: float,
+    ks_key: Any,  # KeyInfo
+    sr: int,
+    tonal_bias: float,
+    bass_bonus: float,
+    bass_confidence_threshold: float = 0.25,
+    min_chroma_norm: float = 0.05,
+    rms_silence_threshold: float = 0.005,
+    trailing_silence_window_s: float = 3.0,
+    trailing_silence_ratio: float = 0.10,
+    merge_same_root: bool = True,
+    max_merge_duration_s: float = 4.0,
+    hop_length: int = 512,
+) -> list:
+    """Run chord estimation independently for each tempo region.
+
+    Variable-tempo path. Each ``TempoRegion`` gets its own
+    ``window/hop/kernel`` derived from its own BPM, then we concatenate
+    the per-region events back into one list (timestamps offset to file
+    time) and run a final same-root merge across the boundaries to
+    consolidate any chord that spans a region edge.
+
+    Beyond the obvious wide-tempo-spread case, the slicing itself
+    appears to give the chord matcher beneficial boundary resets on
+    songs with detected section structure even when the per-region
+    windows are nearly identical — without the resets, chord events
+    bleed across section transitions and confuse the cadential vote.
+    """
+    from harmonic_analysis.audio._chord_estimation import (
+        _merge_same_root_events,
+        estimate_chord_progression,
+    )
+    from harmonic_analysis.audio._tempo import bpm_to_rubato
+
+    fps = sr / hop_length
+    all_events: list[ChordEvent] = []
+
+    for region in regions:
+        region_start_frame = max(0, int((region.start_time - segment_start) * fps))
+        region_end_frame = min(
+            local_chroma.shape[1],
+            int((region.end_time - segment_start) * fps),
+        )
+        if region_end_frame <= region_start_frame:
+            continue
+
+        chroma_slice = local_chroma[:, region_start_frame:region_end_frame]
+        rms_slice = (
+            rms_envelope[region_start_frame:region_end_frame]
+            if rms_envelope is not None
+            else None
+        )
+        bass_slice = (
+            bass_chroma[:, region_start_frame:region_end_frame]
+            if bass_chroma is not None
+            else None
+        )
+
+        window_s, hop_s, kernel = bpm_to_rubato(region.bpm, region.confidence)
+
+        # Defer the merge to the final cross-region pass below.
+        region_events = estimate_chord_progression(
+            chroma_slice,
+            ks_key,
+            sr=sr,
+            hop_length=hop_length,
+            window_size_s=window_s,
+            hop_size_s=hop_s,
+            tonal_bias=tonal_bias,
+            bass_chroma_frames=bass_slice,
+            bass_bonus=bass_bonus,
+            bass_confidence_threshold=bass_confidence_threshold,
+            min_chroma_norm=min_chroma_norm,
+            rms_frames=rms_slice,
+            rms_silence_threshold=rms_silence_threshold,
+            trailing_silence_window_s=trailing_silence_window_s,
+            trailing_silence_ratio=trailing_silence_ratio,
+            median_kernel=kernel,
+            merge_same_root=False,
+        )
+
+        # Offset timestamps from region-local back to file-relative.
+        for ce in region_events:
+            all_events.append(
+                ChordEvent(
+                    start_time=ce.start_time + region.start_time,
+                    end_time=ce.end_time + region.start_time,
+                    chord_label=ce.chord_label,
+                    confidence=ce.confidence,
+                    is_diatonic=ce.is_diatonic,
+                )
+            )
+
+    # Final merge across all boundaries — catches chords that legitimately
+    # span a region edge.
+    if not merge_same_root:
+        return all_events
+    return _merge_same_root_events(
+        all_events, max_merge_duration_s=max_merge_duration_s
+    )
+
+
 def analyze_audio(
     filepath: PathLike,
     *,
@@ -728,11 +927,18 @@ def analyze_audio(
     tonal_bias: float = 0.15,
     use_bass_chroma: bool = False,
     bass_bonus: float = 0.3,
+    bass_confidence_threshold: float = 0.25,
     rubato: Union[str, float] = "moderate",
     min_chroma_norm: float = 0.05,
+    rms_silence_threshold: float = 0.005,
+    trailing_silence_window_s: float = 3.0,
+    trailing_silence_ratio: float = 0.10,
     key_detection: KeyDetectionSpec = _DEFAULT_KEY_DETECTION,
     show_analysis_details: bool = False,
     key_ensemble_weights: Optional[Dict[str, float]] = None,
+    tempo_region_threshold: float = 0.20,
+    merge_same_root: bool = True,
+    max_merge_duration_s: float = 4.0,
 ) -> AudioAnalysisResult:
     """Synchronous convenience wrapper around ``AudioAdapter.from_audio``.
 
@@ -773,11 +979,18 @@ def analyze_audio(
         tonal_bias=tonal_bias,
         use_bass_chroma=use_bass_chroma,
         bass_bonus=bass_bonus,
+        bass_confidence_threshold=bass_confidence_threshold,
         rubato=rubato,
         min_chroma_norm=min_chroma_norm,
+        rms_silence_threshold=rms_silence_threshold,
+        trailing_silence_window_s=trailing_silence_window_s,
+        trailing_silence_ratio=trailing_silence_ratio,
         key_detection=key_detection,
         show_analysis_details=show_analysis_details,
         key_ensemble_weights=key_ensemble_weights,
+        tempo_region_threshold=tempo_region_threshold,
+        merge_same_root=merge_same_root,
+        max_merge_duration_s=max_merge_duration_s,
     )
     return adapter.from_audio(filepath, segment=segment)
 
@@ -793,11 +1006,18 @@ async def analyze_audio_async(
     tonal_bias: float = 0.15,
     use_bass_chroma: bool = False,
     bass_bonus: float = 0.3,
+    bass_confidence_threshold: float = 0.25,
     rubato: Union[str, float] = "moderate",
     min_chroma_norm: float = 0.05,
+    rms_silence_threshold: float = 0.005,
+    trailing_silence_window_s: float = 3.0,
+    trailing_silence_ratio: float = 0.10,
     key_detection: KeyDetectionSpec = _DEFAULT_KEY_DETECTION,
     show_analysis_details: bool = False,
     key_ensemble_weights: Optional[Dict[str, float]] = None,
+    tempo_region_threshold: float = 0.20,
+    merge_same_root: bool = True,
+    max_merge_duration_s: float = 4.0,
 ) -> AudioAnalysisResult:
     """Async convenience wrapper. Offloads librosa work to a worker thread.
 
@@ -839,9 +1059,16 @@ async def analyze_audio_async(
         tonal_bias=tonal_bias,
         use_bass_chroma=use_bass_chroma,
         bass_bonus=bass_bonus,
+        bass_confidence_threshold=bass_confidence_threshold,
         rubato=rubato,
         min_chroma_norm=min_chroma_norm,
+        rms_silence_threshold=rms_silence_threshold,
+        trailing_silence_window_s=trailing_silence_window_s,
+        trailing_silence_ratio=trailing_silence_ratio,
         key_detection=key_detection,
         show_analysis_details=show_analysis_details,
         key_ensemble_weights=key_ensemble_weights,
+        tempo_region_threshold=tempo_region_threshold,
+        merge_same_root=merge_same_root,
+        max_merge_duration_s=max_merge_duration_s,
     )

--- a/tests/audio/_key_approaches/test_cadential.py
+++ b/tests/audio/_key_approaches/test_cadential.py
@@ -215,23 +215,90 @@ def test_v_to_capital_i_major_credits_both_modes_equally() -> None:
     assert d_aeolian == 1.0
 
 
-def test_no_v_motion_returns_empty_verdict() -> None:
-    """Negative case: a sequence with NO (major V → any tonic) adjacent
-    pairs must produce an empty verdict with a populated reason. Cadential
-    refuses to fabricate cadences from non-dominant motion.
+def test_minor_v_to_i_credits_aeolian_only() -> None:
+    """F#m → Bm cadence (natural-minor v→i in B Aeolian) credits B Aeolian
+    ONLY, not B Ionian. This is the regression guard for the dusty_wings
+    bug: songs in pure Aeolian (no raised leading tone) used to get zero
+    cadential credit, leaving their tonic to be miscredited to whichever
+    relative-major sibling shared chord transitions.
 
-    Sequence walk-through (each pair must fail the V→tonic test):
-        Am (minor) → Em (minor): a is minor, skipped (only major V's
-            count as dominants).
-        Em (minor) → Am (minor): a is minor, skipped.
-        Am (minor) → Dm (minor): a is minor, skipped.
-    No major-V dominants in the sequence at all → no cadences.
+    A minor v specifically rules out the major-mode reading (Ionian's V
+    is always major), so a single minor-v→i is a strong Aeolian signal
+    — unlike the major-V→I case where parallel modes are ambiguous and
+    we dual-credit.
     """
     events = [
-        _FakeChordEvent("Am"),
-        _FakeChordEvent("Em"),
-        _FakeChordEvent("Am"),
-        _FakeChordEvent("Dm"),
+        _FakeChordEvent("F#m"),  # minor v
+        _FakeChordEvent("Bm"),  # minor i
+    ]
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
+
+    verdict = CadentialApproach().detect(ctx)
+
+    b_ionian = _find_score(verdict, "B", "Ionian")
+    b_aeolian = _find_score(verdict, "B", "Aeolian")
+    assert b_aeolian == 1.0, f"Expected B Aeolian @ 1.0 from minor v→i; got {b_aeolian}"
+    assert b_ionian == 0.0, (
+        f"Expected B Ionian @ 0.0 from minor v→i (Ionian's V is always "
+        f"major, so minor v rules it out); got {b_ionian}"
+    )
+
+
+def test_mixed_major_v_and_minor_v_to_same_tonic() -> None:
+    """A song with both F#→Bm AND F#m→Bm cadences gives B Aeolian double
+    credit (one from each branch) but B Ionian only single credit (from
+    the major-V branch). Net result: the song leans Aeolian, which is the
+    correct read for repertoire that mixes raised-leading-tone (harmonic
+    minor V) with natural-minor v.
+    """
+    events = [
+        _FakeChordEvent("F#"),  # major V → credits B Ionian + B Aeolian
+        _FakeChordEvent("Bm"),
+        _FakeChordEvent("F#m"),  # minor v → credits B Aeolian only
+        _FakeChordEvent("Bm"),
+    ]
+    ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
+
+    verdict = CadentialApproach().detect(ctx)
+
+    b_ionian = _find_score(verdict, "B", "Ionian")
+    b_aeolian = _find_score(verdict, "B", "Aeolian")
+    # B Aeolian = 2 cadences (1 major + 1 minor), B Ionian = 1 cadence.
+    # Normalized over max=2: Aeolian=1.0, Ionian=0.5.
+    assert b_aeolian == 1.0
+    assert b_ionian == 0.5
+    assert (
+        b_aeolian > b_ionian
+    ), "Aeolian should outscore Ionian when both branches fire"
+
+
+def test_no_v_motion_returns_empty_verdict() -> None:
+    """Negative case: a sequence with NO V→I motions of any kind (neither
+    major-V→I nor minor-v→i) must produce an empty verdict with a
+    populated reason. Cadential refuses to fabricate cadences from
+    non-dominant motion.
+
+    Uses chord pairs whose roots are *not* a fifth apart, so neither
+    branch of cadential's credit logic fires:
+
+        C → D (whole step): not a fifth.
+        D → F# (major third): not a fifth.
+        F# → C (tritone): not a fifth.
+        C → D (back to start): not a fifth.
+
+    All four pairs fail the V→tonic check (a_pc != b_pc + 7), so no
+    cadence credit is awarded for any tonic candidate. Both major and
+    minor cadential branches are exercised by negative — the test
+    documents that *neither* branch fires when there are no fifth
+    relationships, which is what "no V motion" actually means now that
+    minor-v→i is also credited.
+    """
+    events = [
+        _FakeChordEvent("C"),
+        _FakeChordEvent("D"),
+        _FakeChordEvent("F#"),
+        _FakeChordEvent("C"),
+        _FakeChordEvent("D"),
     ]
     ctx = KeyDetectionContext(chroma_1d=_chroma_stub(), chord_events=events)
 

--- a/tests/audio/test_tempo.py
+++ b/tests/audio/test_tempo.py
@@ -1,0 +1,174 @@
+"""Tests for tempo detection and BPM-to-rubato mapping.
+
+Variable-tempo behavior is exercised end-to-end via the audio adapter
+in test_audio_adapter.py; these tests cover the standalone helpers.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from harmonic_analysis.audio._tempo import TempoRegion, _segment_tempo, bpm_to_rubato
+
+
+class TestBpmToRubato:
+    """``bpm_to_rubato`` maps detected BPM to (window, hop, kernel)."""
+
+    def test_low_confidence_falls_back_to_loose(self):
+        """Confidence below threshold ignores BPM and returns the loose
+        preset (0.75s window, 5-frame kernel).
+
+        Material that defeats BPM detection — pop with electronic onsets,
+        heavy reverb, free-tempo classical — is exactly what produces the
+        most chord fragmentation under moderate's 0.5s window. Loose
+        absorbs the ambiguity; callers who want tight grids can pass a
+        static preset explicitly.
+        """
+        # 60 BPM but unreliable — fall back to loose defaults.
+        w, h, k = bpm_to_rubato(60.0, confidence=0.1)
+        assert (w, h, k) == (0.75, 0.4, 5)
+
+    def test_zero_bpm_falls_back_to_loose(self):
+        """Sentinel BPM=0 means detection failed; use loose."""
+        w, h, k = bpm_to_rubato(0.0, confidence=1.0)
+        assert (w, h, k) == (0.75, 0.4, 5)
+
+    def test_classical_tempo_clamps_at_ceiling(self):
+        """At ~70 BPM, raw 2-beat window would be ~1.7s but is capped to 1.0s.
+
+        The cap exists because piano music in this tempo range often has
+        chord-per-beat harmonic rhythm, and a 1.7s window over-smooths
+        the brief dominant chords that key detection relies on. See the
+        bpm_to_rubato docstring for the iwasonce regression that
+        motivated this.
+        """
+        w, h, k = bpm_to_rubato(70.0, confidence=0.8)
+        assert w == 1.0
+        assert h == 0.5
+        assert k == 5
+
+    def test_pop_tempo_gives_full_one_second_window(self):
+        """At 120 BPM, the 2-beat window is exactly 1.0s — at the cap."""
+        w, h, k = bpm_to_rubato(120.0, confidence=0.8)
+        assert w == pytest.approx(1.0, rel=0.01)
+        assert h == pytest.approx(0.5, rel=0.01)
+        assert k == 5
+
+    def test_fast_tempo_below_cap(self):
+        """At 132 BPM (Bach), 2-beat window is 0.91s — below the cap."""
+        w, h, k = bpm_to_rubato(132.0, confidence=0.8)
+        assert w == pytest.approx(0.909, rel=0.01)
+        assert h == pytest.approx(0.455, rel=0.01)
+        assert k == 5
+
+    def test_very_fast_tempo_clamped_at_minimum(self):
+        """Above ~300 BPM the window would go below 0.4s; clamp it."""
+        w, h, k = bpm_to_rubato(400.0, confidence=0.8)
+        assert w == 0.4
+        assert h == 0.2
+        assert k == 3  # below 0.7s threshold → narrow kernel
+
+    def test_very_slow_tempo_clamped_at_ceiling(self):
+        """Below ~120 BPM the 2-beat window exceeds 1.0s; cap to 1.0s."""
+        w, h, k = bpm_to_rubato(40.0, confidence=0.8)
+        assert w == 1.0
+        assert h == 0.5
+        assert k == 5
+
+
+class TestSegmentTempo:
+    """``_segment_tempo`` splits per-frame BPM into constant-tempo regions."""
+
+    SR = 22050  # matches the audio module default
+
+    def test_constant_tempo_one_region(self):
+        """A constant 120-BPM curve produces a single region."""
+        tempo = np.full(800, 120.0)
+        regions = _segment_tempo(
+            tempo, sr=self.SR, segment_start=0.0, change_threshold=0.20
+        )
+        assert len(regions) == 1
+        assert regions[0].bpm == pytest.approx(120.0)
+        assert regions[0].confidence > 0.99
+
+    def test_two_distinct_tempos_split_correctly(self):
+        """A 60-BPM half followed by a 120-BPM half produces two regions."""
+        # 800 frames total, split halfway. fps ~ 43, so each half is ~9s.
+        tempo = np.concatenate([np.full(400, 60.0), np.full(400, 120.0)])
+        regions = _segment_tempo(
+            tempo, sr=self.SR, segment_start=0.0, change_threshold=0.20
+        )
+        assert len(regions) == 2
+        assert regions[0].bpm == pytest.approx(60.0)
+        assert regions[1].bpm == pytest.approx(120.0)
+        # Boundary is at frame 400 → time 400 * (512/22050) ≈ 9.29s
+        boundary = regions[0].end_time
+        assert 8.5 < boundary < 10.0
+
+    def test_wobble_within_threshold_stays_one_region(self):
+        """Per-frame jitter under the change threshold doesn't split."""
+        # Mostly 100 BPM, some frames at 110 (10% wobble — under 20%).
+        rng = np.random.default_rng(42)
+        tempo = 100.0 + rng.uniform(-10, 10, 800)
+        regions = _segment_tempo(
+            tempo, sr=self.SR, segment_start=0.0, change_threshold=0.20
+        )
+        assert (
+            len(regions) == 1
+        ), f"Expected 1 region for sub-threshold wobble, got {len(regions)}"
+
+    def test_single_outlier_does_not_create_region(self):
+        """One spike frame in an otherwise-stable curve doesn't create a new region.
+
+        This is the bug the third-pass mean-merge fixes: pass 1 starts a
+        new region on any frame > threshold from the running mean, but a
+        single outlier frame followed by similar-mean frames shouldn't
+        produce two regions with similar means.
+        """
+        tempo = np.full(800, 100.0)
+        tempo[400] = 200.0  # one wild outlier frame (100% deviation)
+        regions = _segment_tempo(
+            tempo, sr=self.SR, segment_start=0.0, change_threshold=0.20
+        )
+        # The third-pass merge should collapse any same-mean neighbors
+        # back into one region — we should NOT see two regions both
+        # at ~100 BPM.
+        means = [r.bpm for r in regions]
+        assert all(
+            abs(m - 100.0) < 5 for m in means
+        ), f"All region means should be ~100 BPM, got {means}"
+        # And the regions that survived shouldn't all have the same mean
+        # (that's the exact case the merge guards against).
+        if len(regions) > 1:
+            unique_means = set(round(r.bpm, 1) for r in regions)
+            assert (
+                len(unique_means) > 1
+            ), f"Multiple regions all near 100 BPM — merge failed: {means}"
+
+    def test_segment_start_offsets_region_times(self):
+        """``segment_start`` shifts all region times into file time."""
+        tempo = np.full(400, 120.0)
+        regions = _segment_tempo(
+            tempo, sr=self.SR, segment_start=10.0, change_threshold=0.20
+        )
+        assert len(regions) == 1
+        assert regions[0].start_time == pytest.approx(10.0)
+        # End is 10.0 + 400 * (512/22050) ≈ 10 + 9.29 = 19.29
+        assert 18.5 < regions[0].end_time < 20.0
+
+
+class TestTempoRegion:
+    """``TempoRegion`` is a frozen dataclass; sanity-check the contract."""
+
+    def test_frozen(self):
+        r = TempoRegion(start_time=0.0, end_time=10.0, bpm=120.0, confidence=0.9)
+        with pytest.raises((AttributeError, Exception)):
+            r.bpm = 60.0  # type: ignore[misc]
+
+    def test_fields_round_trip(self):
+        r = TempoRegion(start_time=1.5, end_time=10.0, bpm=85.5, confidence=0.7)
+        assert r.start_time == 1.5
+        assert r.end_time == 10.0
+        assert r.bpm == 85.5
+        assert r.confidence == 0.7


### PR DESCRIPTION
## Summary

- **Tempo detection** with octave-folding + median-smoothing so librosa's per-frame multiples (84/112/172) collapse into a stable canonical octave. New `auto` rubato preset sizes the chord window to ~2 beats (capped at 1.0s).
- **Adaptive silence gate** (trailing-RMS envelope) catches fade-outs that the absolute floor misses, plus a same-root post-merge collapses ping-pong chord events.
- **Cadential approach** now credits minor v→i (Aeolian-only), fixing modal songs whose tonic was being handed to the relative major.
- **Per-region chord estimation** runs when auto detects multiple tempo regions, with a same-window guard so it only fires when it has work to do.
- **Demo** defaults to `rubato="auto"`, surfaces BPM + tempo regions in the headline panel, and exposes 8 previously-internal chord-estimation params in the advanced panel grouped by pipeline phase.

## Verified on four real-world fixtures

| File | Expected | Detected | BPM | Regions | Chord events | Conf |
|---|---|---|---|---|---|---|
| Bach WTC Book 1 Prelude in C | C Ionian | ✓ C Ionian | 133 | 1 | 45 | 0.98 |
| in-betweens (pop, C# major) | C# Ionian | ✓ C# Ionian | 86 | 5 | 101 | 0.91 |
| dusty_wings (modal B minor) | B Aeolian | ✓ B Aeolian | 117 | 13 | 158 | 0.92 |
| iwasonce (solo piano, free tempo) | B Aeolian | ✓ B Aeolian | 91 | 1 | 86 | 0.88 |

## Test plan

- [x] 139 backend tests pass (`pytest tests/audio/ tests/integration/test_audio_adapter.py`)
- [x] 13 new tempo tests added in `tests/audio/test_tempo.py` (cap behavior, region single/multi cases, wobble suppression, single-outlier robustness, segment offsetting)
- [x] 2 new cadential tests added (`test_minor_v_to_i_credits_aeolian_only` regression guard for dusty_wings, `test_mixed_major_v_and_minor_v_to_same_tonic` for the modal-mixture case)
- [x] 67 frontend vitest tests pass
- [x] `tsc -b` clean
- [x] Smoke test: upload each of the 4 fixtures via the demo and confirm the headline panel shows correct key, BPM, region count, and that the chord-event table reads as expected

## Notes for reviewers

- The per-region chord estimation path looks redundant on small test sets (it gets bypassed by the same-window guard for most material). It actually does meaningful work on dusty_wings via the slicing itself, not via different windows — there's a code comment explaining the empirical-not-theoretical reason it stays. I tried stripping it and dusty_wings flipped to G Ionian; reverted.
- The 1.0s cap on auto-window was tuned to fix iwasonce (slow piano with chord-per-beat rhythm needed narrower windows to detect brief V chords). Bach is unaffected (132 BPM → 0.91s, below cap).
- All 8 newly-exposed advanced params already have library defaults that are calibrated for general-purpose material — the demo passes them through only when the user has explicitly nudged them off-default.