### PR TITLE
feat(demo): redesign Tab 1 as fixed-height two-column workbench

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Demo Tab 1 ("Manual entry") reskinned as a fixed-height two-column "workbench" layout.** The shipping page stacked vertically — intro paragraph, input form, Python snippet card, then results — which pushed the analysis below the laptop fold on most viewports. The new layout pins a 340-px input panel to the left edge (chord textarea, four quick-example chips including the new `Mixolydian ♭VII → G F C G`, key + profile selects, educational-notes checkbox, primary Analyze button + "View as Python" link) and gives the right column its own scroll for the full `AnalysisResults` block. The page itself no longer scrolls — only the right column does — so the user can edit chords and re-analyze without losing track of where they are. Four new presentational components carry the structure: `WorkbenchLayout`, `InputPanel`, `EmptyAnalysisState`, and `CodeModal`. The page-level Python `SectionCard` moved into `CodeModal`, which now offers a 3 × 3 matrix of feature (Manual / Notation / Audio) × language (Python / CLI / curl) snippets with copy-to-clipboard, JSX-tokenized syntax highlighting (no raw HTML injection), and three-way dismiss (Escape, backdrop click, ×). Implements Proposal D from the design handoff. Affects only the demo frontend; library code and APIs unchanged.
+
 ## [0.3.1-beta.4] - 2026-05-10
 
 ### Changed

--- a/demo/frontend/src/components/CodeModal.tsx
+++ b/demo/frontend/src/components/CodeModal.tsx
@@ -1,0 +1,422 @@
+// Centered modal containing the "Use this from code" panel. Opened from the
+// "View as Python" link in Tab 1's input footer. Three-feature × three-language
+// matrix: pick which feature's snippet to show (Manual / Notation / Audio),
+// pick the language (py / cli / curl), copy to clipboard, dismiss via × /
+// backdrop / Escape.
+//
+// Snippet content is the same shape the prototype shipped — keep them in sync
+// with whatever lives in `/docs/` if those examples ever drift.
+
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import Eyebrow from './ui/Eyebrow';
+
+export type CodeModalTab = 'manual' | 'upload' | 'audio';
+export type CodeModalLang = 'py' | 'cli' | 'curl';
+
+interface CodeModalProps {
+  open: boolean;
+  initialTab?: CodeModalTab;
+  initialLang?: CodeModalLang;
+  onClose: () => void;
+}
+
+// Per-feature snippets. Bodies are intentionally compact — the modal isn't a
+// tutorial, just a "here's the same call from your editor" pointer.
+//
+// `label` is the long-form name (used in the body eyebrow); `short` is the
+// compact name that fits the toolbar pill without wrapping.
+const CODE_TABS: Record<
+  CodeModalTab,
+  { label: string; short: string; summary: string; py: string; cli: string; curl: string }
+> = {
+  manual: {
+    label: 'Manual entry',
+    short: 'Manual',
+    summary:
+      'Hand a list of chord symbols to the engine. Optionally pin the key or the style profile, and turn on educational explanations.',
+    py: `from harmonic_analysis.services import PatternAnalysisService
+
+service = PatternAnalysisService()
+
+result = await service.analyze_with_patterns_async(
+    ['Dm', 'G7', 'Cmaj7'],
+    key="C major",            # optional — None = auto-detect
+    profile="classical",      # or "jazz", "pop", "modal", None
+    include_educational=True,
+)
+
+print(result.primary.key_signature)     # → "C major"
+print(result.primary.roman_numerals)    # → ['ii', 'V7', 'Imaj7']
+print(result.primary.confidence)        # → 0.92`,
+    cli: `# CLI equivalent
+ha analyze "Dm G7 Cmaj7" --key "C major" --profile classical --educational`,
+    curl: `curl -X POST http://localhost:8000/api/analyze \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "chords": ["Dm", "G7", "Cmaj7"],
+    "key": "C major",
+    "profile": "classical",
+    "include_educational": true
+  }'`,
+  },
+  upload: {
+    label: 'Analyze notation',
+    short: 'Notation',
+    summary:
+      'Feed a MusicXML or MIDI file to the same engine. The library extracts the chord progression from the notation and runs the same multi-profile analysis as manual entry.',
+    py: `from harmonic_analysis.services import (
+    PatternAnalysisService,
+    MusicFileProcessor,
+)
+
+processor = MusicFileProcessor()
+extracted = processor.process_file("etude.musicxml")
+
+# extracted.chord_symbols → ['Am', 'Dm', 'G', 'C', ...]
+# extracted.key_hint      → "A minor"
+
+service = PatternAnalysisService()
+result  = await service.analyze_with_patterns_async(
+    extracted.chord_symbols,
+    key=extracted.key_hint,
+    profile="classical",
+)`,
+    cli: `# CLI equivalent
+ha analyze-file etude.musicxml --profile classical`,
+    curl: `curl -X POST http://localhost:8000/api/analyze/file \\
+  -F "file=@etude.musicxml" \\
+  -F "profile=classical" \\
+  -F "run_analysis=true"`,
+  },
+  audio: {
+    label: 'Audio analysis',
+    short: 'Audio',
+    summary:
+      'Run key detection + time-aligned chord estimation on a recording, then optionally hand the extracted chord labels back to the pattern engine for the full Roman-numeral reading.',
+    py: `from harmonic_analysis.audio   import AudioAnalyzer
+from harmonic_analysis.services import PatternAnalysisService
+
+# 1. audio → time-aligned chords + key
+audio = AudioAnalyzer()
+audio_result = await audio.analyze_file("riff.wav")
+
+# 2. (optional) feed the chord labels into pattern analysis
+labels = [c.chord_label for c in audio_result.chord_progression]
+service = PatternAnalysisService()
+patterns = await service.analyze_with_patterns_async(
+    labels,
+    key=f"{audio_result.local.tonic} {audio_result.local.mode}",
+    include_educational=True,
+)`,
+    cli: `# CLI equivalent
+ha analyze-audio riff.wav --run-pattern-analysis`,
+    curl: `curl -X POST http://localhost:8000/api/analyze/audio \\
+  -F "file=@riff.wav" \\
+  -F "run_pattern_analysis=true"`,
+  },
+};
+
+// Token order matters: comments first so `#` lines don't get keyword-painted;
+// strings next so quoted text isn't accidentally split on keyword regex; then
+// keywords last on whatever remains. Each token type produces a span with its
+// own color. Returns a list of React nodes — no raw HTML, no innerHTML.
+const PY_KEYWORDS = new Set([
+  'from', 'import', 'as', 'async', 'await', 'def', 'return', 'None', 'True',
+  'False', 'in', 'for', 'if', 'else', 'elif', 'with', 'class', 'print',
+]);
+
+const IDENT_RE = /^[A-Za-z_][A-Za-z0-9_]*/;
+const PLAIN_RE = /^[^"'#A-Za-z_]+/;
+
+// Walk a single line, peeling off the leftmost match of comment / string /
+// keyword / plain at each step. Cheap to implement, plenty fast for the size of
+// snippet we're showing.
+const tokenizePythonLine = (line: string): ReactNode[] => {
+  const out: ReactNode[] = [];
+  let i = 0;
+  let key = 0;
+  while (i < line.length) {
+    // Comment to end of line
+    if (line[i] === '#') {
+      out.push(
+        <span key={key++} className="text-slate-400 italic">
+          {line.slice(i)}
+        </span>,
+      );
+      break;
+    }
+    // String literal — single or double quoted, simple (no escape handling)
+    if (line[i] === '"' || line[i] === "'") {
+      const quote = line[i];
+      const end = line.indexOf(quote, i + 1);
+      const stop = end === -1 ? line.length : end + 1;
+      out.push(
+        <span key={key++} className="text-emerald-700">
+          {line.slice(i, stop)}
+        </span>,
+      );
+      i = stop;
+      continue;
+    }
+    // Identifier / keyword (letters, digits, underscore)
+    const remaining = line.slice(i);
+    const ident = remaining.match(IDENT_RE);
+    if (ident) {
+      const word = ident[0];
+      if (PY_KEYWORDS.has(word)) {
+        out.push(
+          <span key={key++} className="text-primary-700 font-semibold">
+            {word}
+          </span>,
+        );
+      } else {
+        out.push(<Fragment key={key++}>{word}</Fragment>);
+      }
+      i += word.length;
+      continue;
+    }
+    // Plain run — anything that isn't a quote, hash, or identifier-start
+    const plain = remaining.match(PLAIN_RE);
+    if (plain) {
+      out.push(<Fragment key={key++}>{plain[0]}</Fragment>);
+      i += plain[0].length;
+      continue;
+    }
+    // Defensive: should be unreachable, but advance to avoid an infinite loop
+    out.push(<Fragment key={key++}>{line[i]}</Fragment>);
+    i += 1;
+  }
+  return out;
+};
+
+const PythonHighlight = ({ src }: { src: string }) => {
+  const lines = src.split('\n');
+  return (
+    <>
+      {lines.map((line, idx) => (
+        <Fragment key={idx}>
+          {tokenizePythonLine(line)}
+          {idx < lines.length - 1 ? '\n' : ''}
+        </Fragment>
+      ))}
+    </>
+  );
+};
+
+// Inline </> glyph — matches the eighth-note family used in Header.tsx.
+const CodeIcon = ({ className = 'w-4 h-4' }: { className?: string }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    aria-hidden="true"
+  >
+    <polyline points="16 18 22 12 16 6" />
+    <polyline points="8 6 2 12 8 18" />
+  </svg>
+);
+
+const CopyIcon = ({ className = 'w-3.5 h-3.5' }: { className?: string }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    aria-hidden="true"
+  >
+    <rect x="9" y="9" width="13" height="13" rx="2" />
+    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+  </svg>
+);
+
+const CodeModal = ({ open, initialTab = 'manual', initialLang = 'py', onClose }: CodeModalProps) => {
+  const [tab, setTab] = useState<CodeModalTab>(initialTab);
+  const [lang, setLang] = useState<CodeModalLang>(initialLang);
+  const [copied, setCopied] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Resync when reopened with a different default — avoids the modal showing
+  // stale tab state from the previous open.
+  useEffect(() => {
+    if (open) {
+      setTab(initialTab);
+      setLang(initialLang);
+      setCopied(false);
+    }
+  }, [open, initialTab, initialLang]);
+
+  // Escape dismisses; mounting/unmounting the listener with `open` so closed
+  // modals don't poison the global keymap.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  // Lock body scroll while the modal is up — otherwise the page behind the
+  // backdrop can still scroll under the user's pointer.
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  const current = CODE_TABS[tab];
+  const src = useMemo(() => {
+    if (lang === 'py') return current.py;
+    if (lang === 'cli') return current.cli;
+    return current.curl;
+  }, [current, lang]);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(src);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1400);
+    } catch {
+      // Some browsers refuse clipboard in insecure contexts. Silent fail is
+      // better than throwing — the snippet is still selectable.
+    }
+  }, [src]);
+
+  if (!open) return null;
+
+  const tabs: CodeModalTab[] = ['manual', 'upload', 'audio'];
+  const langs: CodeModalLang[] = ['py', 'cli', 'curl'];
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="code-modal-title"
+    >
+      {/* Backdrop — click to dismiss. */}
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close code panel"
+        className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm cursor-default"
+      />
+
+      <div
+        ref={dialogRef}
+        className="relative z-10 w-[680px] max-w-[92vw] max-h-[85vh] rounded-2xl border border-slate-200 bg-white shadow-[0_-8px_32px_rgba(15,23,42,0.10),0_-2px_8px_rgba(15,23,42,0.04)] overflow-hidden flex flex-col"
+      >
+        {/* Toolbar — flex-wrap so cramped viewports stack the title above the
+            controls instead of truncating. Short tab labels (Manual / Notation
+            / Audio) keep the pill compact; the long label still shows as the
+            body eyebrow so context isn't lost. */}
+        <div className="flex items-center justify-between gap-x-3 gap-y-2 flex-wrap px-5 py-3 border-b border-slate-200 bg-slate-50/60 flex-shrink-0">
+          <div className="flex items-center gap-2 min-w-0">
+            <CodeIcon className="w-4 h-4 text-primary-700 flex-shrink-0" />
+            <span
+              id="code-modal-title"
+              className="font-serif text-lg font-semibold text-slate-900 leading-none whitespace-nowrap"
+            >
+              Use this from code
+            </span>
+          </div>
+          <div className="flex items-center gap-2 flex-wrap">
+            {/* Feature tab toggle */}
+            <div className="flex items-center gap-1 bg-white border border-slate-200 rounded-md p-0.5">
+              {tabs.map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setTab(t)}
+                  className={`text-xs px-2 py-1 rounded transition whitespace-nowrap ${
+                    tab === t
+                      ? 'bg-slate-900 text-white'
+                      : 'text-slate-600 hover:text-slate-900'
+                  }`}
+                >
+                  {CODE_TABS[t].short}
+                </button>
+              ))}
+            </div>
+            {/* Language toggle */}
+            <div className="flex items-center gap-1 text-[11px] font-mono">
+              {langs.map((l) => (
+                <button
+                  key={l}
+                  type="button"
+                  onClick={() => setLang(l)}
+                  className={`px-1.5 py-0.5 rounded uppercase tracking-wider border ${
+                    lang === l
+                      ? 'bg-primary-50 text-primary-800 border-primary-200'
+                      : 'text-slate-500 hover:text-slate-800 border-transparent'
+                  }`}
+                >
+                  {l}
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="inline-flex items-center gap-1 bg-white hover:bg-slate-50 text-slate-700 border border-slate-200 font-medium py-1 px-2 rounded-lg text-xs transition"
+            >
+              <CopyIcon />
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="w-7 h-7 grid place-items-center rounded-md hover:bg-slate-200 text-slate-500"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-4 space-y-3 overflow-y-auto">
+          <Eyebrow tone="primary">{current.label}</Eyebrow>
+          <p className="text-sm text-slate-600 leading-relaxed">{current.summary}</p>
+          <pre
+            className="text-[12px] leading-[1.65] font-mono text-slate-800 bg-slate-50 px-4 py-3 rounded-lg overflow-x-auto border border-slate-200"
+            aria-label={`${lang} sample`}
+          >
+            <code>{lang === 'py' ? <PythonHighlight src={src} /> : src}</code>
+          </pre>
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-slate-500">
+            <a
+              href="https://github.com/sammywachtel/harmonic-analysis/blob/main/docs/README.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary-700 hover:underline"
+            >
+              Full API reference →
+            </a>
+            <a
+              href="https://pypi.org/project/harmonic-analysis/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-slate-600 hover:underline"
+            >
+              Install on PyPI →
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CodeModal;

--- a/demo/frontend/src/components/EmptyAnalysisState.tsx
+++ b/demo/frontend/src/components/EmptyAnalysisState.tsx
@@ -1,0 +1,21 @@
+// Placeholder shown in the right column of the workbench before the user has
+// run an analysis. The outer wrapper claims `h-full` so the dashed card can
+// stretch and center against the available column height — without this the
+// card would float near the top of a tall right column, looking lonely.
+
+import Eyebrow from './ui/Eyebrow';
+
+const EmptyAnalysisState = () => (
+  <div className="h-full min-h-[24rem] rounded-2xl border border-dashed border-slate-300 bg-white/50 flex flex-col items-center justify-center text-center px-8 py-12">
+    <Eyebrow className="mb-2">Waiting for input</Eyebrow>
+    <h2 className="font-serif text-2xl text-slate-900 mb-2 tracking-tight">
+      No analysis yet
+    </h2>
+    <p className="text-sm text-slate-500 max-w-sm leading-relaxed">
+      Edit the chords on the left and press{' '}
+      <span className="font-mono text-slate-700">Analyze</span> to see the engine's reading here.
+    </p>
+  </div>
+);
+
+export default EmptyAnalysisState;

--- a/demo/frontend/src/components/InputPanel.tsx
+++ b/demo/frontend/src/components/InputPanel.tsx
@@ -1,0 +1,226 @@
+// Left column of the Tab 1 workbench. Three vertical regions:
+//
+//   1. Title strip      — eyebrow + serif H1 + helper line
+//   2. Form body        — chord textarea, quick-example chips, key + profile
+//                         selects, educational notes checkbox (scrollable for
+//                         very short viewports)
+//   3. Action footer    — primary Analyze button + "View as Python" link
+//
+// State and behavior live up in Tab1.tsx — this is a presentational shell.
+// Everything the user can change is passed in as a value + onChange pair so
+// Tab1.tsx remains the single source of truth.
+
+import Eyebrow from './ui/Eyebrow';
+
+interface KeyOption {
+  value: string;
+  label: string;
+}
+
+interface InputPanelProps {
+  chordsInput: string;
+  onChordsChange: (value: string) => void;
+  keyOptions: KeyOption[];
+  selectedKey: string;
+  onKeyChange: (value: string) => void;
+  profileOptions: KeyOption[];
+  selectedProfile: string;
+  onProfileChange: (value: string) => void;
+  showEducational: boolean;
+  onEducationalChange: (value: boolean) => void;
+  loading: boolean;
+  analyzed: boolean;
+  onAnalyze: () => void;
+  showCodeLink: boolean;
+  onViewCode: () => void;
+}
+
+// Quick examples — vertical stack, each chip shows the Roman label on the
+// left and the chord preview on the right. Hover paints the chip in coral.
+const EXAMPLES: Array<{ label: string; chords: string }> = [
+  { label: 'I – vi – IV – V',  chords: 'C  Am  F  G' },
+  { label: 'ii – V – I',       chords: 'Dm  G7  Cmaj7' },
+  { label: 'I – V – vi – IV',  chords: 'C  G  Am  F' },
+  { label: 'Mixolydian ♭VII',  chords: 'G  F  C  G' },
+];
+
+const CodeIcon = ({ className = 'w-3.5 h-3.5' }: { className?: string }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    aria-hidden="true"
+  >
+    <polyline points="16 18 22 12 16 6" />
+    <polyline points="8 6 2 12 8 18" />
+  </svg>
+);
+
+const inputClass =
+  'w-full px-3 py-2 bg-white border border-slate-300 rounded-lg text-sm focus:ring-2 focus:ring-primary-500 focus:border-transparent transition';
+
+const InputPanel = ({
+  chordsInput,
+  onChordsChange,
+  keyOptions,
+  selectedKey,
+  onKeyChange,
+  profileOptions,
+  selectedProfile,
+  onProfileChange,
+  showEducational,
+  onEducationalChange,
+  loading,
+  analyzed,
+  onAnalyze,
+  showCodeLink,
+  onViewCode,
+}: InputPanelProps) => {
+  // Disable the primary button when there's nothing to analyze or a request
+  // is already in flight. Loading wins over analyzed for the label so the user
+  // sees "Analyzing…" while a re-analyze is mid-flight.
+  const buttonLabel = loading
+    ? 'Analyzing…'
+    : analyzed
+      ? 'Re-analyze ↻'
+      : 'Analyze progression →';
+
+  return (
+    <>
+      {/* Title strip — never scrolls */}
+      <div className="px-6 pt-6 pb-4 border-b border-slate-100 flex-shrink-0">
+        <Eyebrow tone="primary" className="mb-1">Manual entry</Eyebrow>
+        <h1 className="font-serif text-2xl font-semibold text-slate-900 tracking-tight">
+          Chord progression
+        </h1>
+        <p className="text-xs text-slate-500 mt-1.5 leading-relaxed">
+          Type chords. The analysis updates on the right.
+        </p>
+      </div>
+
+      {/* Form body — scrolls if the panel ever overflows on a short viewport */}
+      <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5 min-h-0">
+        <div>
+          <label
+            htmlFor="chords"
+            className="block text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500 mb-1.5"
+          >
+            Chords
+          </label>
+          <textarea
+            id="chords"
+            value={chordsInput}
+            onChange={(e) => onChordsChange(e.target.value)}
+            rows={3}
+            className={`${inputClass} font-mono`}
+            placeholder="C  Am  F  G"
+            aria-describedby="chords-help"
+          />
+          <p id="chords-help" className="mt-1.5 text-[11px] text-slate-500 leading-relaxed">
+            Letters with sharps, flats, slashes — separated by spaces, commas, or newlines.
+          </p>
+        </div>
+
+        <div>
+          <Eyebrow className="mb-2">Quick examples</Eyebrow>
+          <div className="flex flex-col gap-1.5">
+            {EXAMPLES.map((ex) => (
+              <button
+                key={ex.label}
+                type="button"
+                onClick={() => onChordsChange(ex.chords)}
+                className="group text-left text-xs bg-slate-50 border border-slate-200 px-2.5 py-1.5 rounded hover:border-primary-300 hover:bg-primary-50 transition flex items-center justify-between gap-2"
+              >
+                <span className="font-mono text-slate-700">{ex.label}</span>
+                <span className="font-mono text-[10px] text-slate-400 group-hover:text-primary-700">
+                  {ex.chords}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label
+            htmlFor="key"
+            className="block text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500 mb-1.5"
+          >
+            Key hint
+          </label>
+          <select
+            id="key"
+            value={selectedKey}
+            onChange={(e) => onKeyChange(e.target.value)}
+            className={inputClass}
+          >
+            {keyOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label
+            htmlFor="profile"
+            className="block text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500 mb-1.5"
+          >
+            Profile focus
+          </label>
+          <select
+            id="profile"
+            value={selectedProfile}
+            onChange={(e) => onProfileChange(e.target.value)}
+            className={inputClass}
+            data-testid="profile-selector"
+          >
+            {profileOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <label className="flex items-center gap-2 cursor-pointer select-none text-sm text-slate-700">
+          <input
+            type="checkbox"
+            checked={showEducational}
+            onChange={(e) => onEducationalChange(e.target.checked)}
+            className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-slate-300 rounded"
+          />
+          Educational notes
+        </label>
+      </div>
+
+      {/* Action footer — pinned at the bottom of the column */}
+      <div className="border-t border-slate-100 px-6 py-4 space-y-2.5 bg-slate-50/40 flex-shrink-0">
+        <button
+          type="button"
+          onClick={onAnalyze}
+          disabled={loading || !chordsInput.trim()}
+          className="w-full bg-primary-600 hover:bg-primary-700 disabled:bg-slate-300 disabled:cursor-not-allowed text-white font-semibold py-2.5 px-5 rounded-lg transition shadow-sm"
+        >
+          {buttonLabel}
+        </button>
+        {showCodeLink && (
+          <button
+            type="button"
+            onClick={onViewCode}
+            className="w-full inline-flex items-center justify-center gap-1.5 text-[12px] font-mono text-slate-500 hover:text-primary-700 transition py-1.5"
+          >
+            <CodeIcon />
+            View as Python
+          </button>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default InputPanel;

--- a/demo/frontend/src/components/WorkbenchLayout.tsx
+++ b/demo/frontend/src/components/WorkbenchLayout.tsx
@@ -1,0 +1,37 @@
+// Two-column "workbench" frame used by Tab 1. The whole point is that the
+// input column never moves while the analysis column scrolls independently —
+// the user can keep editing chords without losing sight of where they are.
+//
+// Height math (matters because we escape Layout's chrome to claim viewport):
+//   - Header is sticky h-14 = 56px.
+//   - Layout's <main> has px-6 py-8 (24px sides, 32px top/bottom).
+//   - TabNavigation sits inside main with -mt-2 mb-8, contributing about
+//     46px of content + 32px bottom gap.
+//   - We escape with `-mt-8 -mx-6` (cancels main's pt-8 and the tabnav gap +
+//     pulls flush to the edges), then claim `h-[calc(100vh-7.5rem)]` — that
+//     leaves room for the header, tabnav, and a hair of breathing space.
+//
+// Footer continues to live inside Layout but ends up below the viewport on
+// this tab. The user can scroll the page to reveal it; the workbench area
+// itself doesn't scroll — only the right column does. That's the design
+// intent: a fixed working surface with a scrolling result feed.
+
+import type { ReactNode } from 'react';
+
+interface WorkbenchLayoutProps {
+  input: ReactNode;
+  analysis: ReactNode;
+}
+
+const WorkbenchLayout = ({ input, analysis }: WorkbenchLayoutProps) => (
+  <div className="-mt-8 -mx-6 h-[calc(100vh-7.5rem)] flex border-t border-slate-200 bg-white overflow-hidden">
+    <aside className="w-[340px] flex-shrink-0 h-full bg-white border-r border-slate-200 flex flex-col overflow-hidden">
+      {input}
+    </aside>
+    <section className="flex-1 min-w-0 h-full overflow-y-auto bg-slate-50">
+      {analysis}
+    </section>
+  </div>
+);
+
+export default WorkbenchLayout;

--- a/demo/frontend/src/tabs/Tab1.tsx
+++ b/demo/frontend/src/tabs/Tab1.tsx
@@ -1,20 +1,24 @@
 // Tab 1 — Manual entry. The user types chord symbols, optionally pins a key
 // and a style profile, and the engine returns a full multi-profile reading.
 //
-// Layout (per design README):
-//   1. Page intro (serif h1 + slate subtitle)
-//   2. Input panel (SectionCard) — chord textarea, examples, key + profile,
-//      educational toggle, analyze button
-//   3. Python API example (SectionCard, demo mode only)
-//   4. Error banner (rose-toned SectionCard)
-//   5. AnalysisResults — hero card + Roman score + patterns + ...
+// Layout (per design README — "Workbench" / Proposal D):
+//   - Fixed two-column frame that fills the viewport below the app header/tabs.
+//   - LEFT (340px, fixed): InputPanel — title strip, scrollable form body,
+//     pinned action footer with Analyze button + "View as Python" link.
+//   - RIGHT (flex-1, scrolls): error banner (if any), then either an empty
+//     state placeholder or the full AnalysisResults block.
+//
+// The page-level Python "SectionCard" that used to sit inline is gone — that
+// content now lives in CodeModal, opened from the View-as-Python link.
 
 import { useState, useEffect } from 'react';
 import { analyzeChords, fetchKeys } from '../api/analysis';
 import type { AnalysisResponse } from '../types/analysis';
 import AnalysisResults from '../components/AnalysisResults';
-import SectionCard from '../components/ui/SectionCard';
-import Tag from '../components/ui/Tag';
+import WorkbenchLayout from '../components/WorkbenchLayout';
+import InputPanel from '../components/InputPanel';
+import EmptyAnalysisState from '../components/EmptyAnalysisState';
+import CodeModal from '../components/CodeModal';
 import { isDemoMode } from '../config/environment';
 
 const Tab1 = () => {
@@ -26,6 +30,7 @@ const Tab1 = () => {
   const [error, setError] = useState<string | null>(null);
   const [results, setResults] = useState<AnalysisResponse | null>(null);
   const [analyzedChords, setAnalyzedChords] = useState<string[]>([]);
+  const [codeModalOpen, setCodeModalOpen] = useState(false);
 
   const demoMode = isDemoMode();
 
@@ -70,7 +75,6 @@ const Tab1 = () => {
     try {
       setLoading(true);
       setError(null);
-      setResults(null);
       const chords = chordsInput.split(/[,\s\n]+/).map((c) => c.trim()).filter(Boolean);
       const response = await analyzeChords({
         chords,
@@ -88,190 +92,76 @@ const Tab1 = () => {
     }
   };
 
-  const loadExample = (example: string) => {
-    setChordsInput(example);
-    setError(null);
-    setResults(null);
-  };
-
-  const inputClass =
-    'w-full px-3 py-2 bg-white border border-slate-300 rounded-lg text-sm focus:ring-2 focus:ring-primary-500 focus:border-transparent transition';
-
   return (
-    <div className="space-y-8">
-      {/* Page intro */}
-      <header>
-        <h1 className="font-serif font-semibold text-4xl text-slate-900 tracking-tight">
-          Manual entry
-        </h1>
-        <p className="mt-2 text-slate-600 max-w-2xl text-base leading-relaxed">
-          Type a chord progression. The engine returns a key estimate, Roman numerals, and a
-          full pattern analysis — with optional Bernstein-style educational explanations.
-        </p>
-      </header>
-
-      {/* Input panel */}
-      <SectionCard
-        eyebrow="Input"
-        title="Chord progression"
-        subtitle="Use letter names; spaces, commas, or newlines all separate chords"
-      >
-        <div className="space-y-5">
-          <div>
-            <label htmlFor="chords" className="block text-sm font-medium text-slate-700 mb-2">
-              Chords
-            </label>
-            <textarea
-              id="chords"
-              value={chordsInput}
-              onChange={(e) => setChordsInput(e.target.value)}
-              placeholder="Example: C  Am  F  G"
-              rows={3}
-              className={`${inputClass} font-mono`}
-              aria-describedby="chords-help"
-            />
-            <p id="chords-help" className="mt-1.5 text-xs text-slate-500">
-              Chord symbols like C, Dm, G7, Fmaj7, B♭/D, etc.
-            </p>
-          </div>
-
-          {/* Quick example buttons */}
-          <div>
-            <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500 mb-2">
-              Quick examples
+    <>
+      <WorkbenchLayout
+        input={
+          <InputPanel
+            chordsInput={chordsInput}
+            onChordsChange={(value) => {
+              setChordsInput(value);
+              if (error) setError(null);
+            }}
+            keyOptions={keyOptions}
+            selectedKey={selectedKey}
+            onKeyChange={setSelectedKey}
+            profileOptions={profileOptions}
+            selectedProfile={selectedProfile}
+            onProfileChange={setSelectedProfile}
+            showEducational={showEducational}
+            onEducationalChange={setShowEducational}
+            loading={loading}
+            analyzed={!!results}
+            onAnalyze={handleAnalyze}
+            showCodeLink={demoMode}
+            onViewCode={() => setCodeModalOpen(true)}
+          />
+        }
+        analysis={
+          // Two wrappers because the layouts genuinely differ. With results
+          // (or an error) we want natural top-to-bottom flow so the right
+          // column can scroll. With the empty state we want the whole column
+          // height so the dashed card centers vertically per the design spec.
+          results || error ? (
+            <div className="max-w-3xl mx-auto px-8 py-8 space-y-8">
+              {error && (
+                <div
+                  role="alert"
+                  className="rounded-2xl border border-rose-200 bg-rose-50/70 px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]"
+                >
+                  <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-rose-700 font-mono mb-1">
+                    Error
+                  </div>
+                  <h3 className="text-base font-semibold text-slate-900 font-serif tracking-tight mb-1.5">
+                    Couldn't analyze that
+                  </h3>
+                  <p className="text-sm text-rose-800">{error}</p>
+                </div>
+              )}
+              {results && (
+                <AnalysisResults
+                  results={results}
+                  showEducational={showEducational}
+                  chords={analyzedChords}
+                />
+              )}
             </div>
-            <div className="flex flex-wrap gap-2">
-              <button
-                type="button"
-                onClick={() => loadExample('C  Am  F  G')}
-                className="text-sm bg-slate-50 hover:bg-primary-50 hover:text-primary-800 hover:border-primary-200 border border-slate-200 px-3 py-1.5 rounded-md transition font-mono text-slate-700"
-              >
-                I – vi – IV – V
-              </button>
-              <button
-                type="button"
-                onClick={() => loadExample('Dm  G7  Cmaj7')}
-                className="text-sm bg-slate-50 hover:bg-primary-50 hover:text-primary-800 hover:border-primary-200 border border-slate-200 px-3 py-1.5 rounded-md transition font-mono text-slate-700"
-              >
-                ii – V – I
-              </button>
-              <button
-                type="button"
-                onClick={() => loadExample('C  G  Am  F')}
-                className="text-sm bg-slate-50 hover:bg-primary-50 hover:text-primary-800 hover:border-primary-200 border border-slate-200 px-3 py-1.5 rounded-md transition font-mono text-slate-700"
-              >
-                I – V – vi – IV
-              </button>
+          ) : (
+            <div className="h-full max-w-3xl mx-auto px-8 py-8 flex flex-col">
+              <div className="flex-1 min-h-0">
+                <EmptyAnalysisState />
+              </div>
             </div>
-          </div>
-
-          {/* Key + Profile in a 2-col grid on wider screens */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div>
-              <label htmlFor="key" className="block text-sm font-medium text-slate-700 mb-2">
-                Key hint <span className="text-slate-400 font-normal">(optional)</span>
-              </label>
-              <select
-                id="key"
-                value={selectedKey}
-                onChange={(e) => setSelectedKey(e.target.value)}
-                className={inputClass}
-              >
-                {keyOptions.map((opt) => (
-                  <option key={opt.value} value={opt.value}>{opt.label}</option>
-                ))}
-              </select>
-              <p className="mt-1.5 text-xs text-slate-500">
-                Leave on Auto-detect to let the engine choose.
-              </p>
-            </div>
-
-            <div>
-              <label htmlFor="profile" className="block text-sm font-medium text-slate-700 mb-2">
-                Profile focus <span className="text-slate-400 font-normal">(optional)</span>
-              </label>
-              <select
-                id="profile"
-                value={selectedProfile}
-                onChange={(e) => setSelectedProfile(e.target.value)}
-                className={inputClass}
-                data-testid="profile-selector"
-              >
-                {profileOptions.map((opt) => (
-                  <option key={opt.value} value={opt.value}>{opt.label}</option>
-                ))}
-              </select>
-              <p className="mt-1.5 text-xs text-slate-500">
-                Emphasize one style, or leave empty for the full multi-profile breakdown.
-              </p>
-            </div>
-          </div>
-
-          {/* Educational toggle */}
-          <label className="flex items-center gap-2 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              id="show-educational"
-              checked={showEducational}
-              onChange={(e) => setShowEducational(e.target.checked)}
-              className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-slate-300 rounded"
-            />
-            <span className="text-sm text-slate-700">Show educational explanations on patterns</span>
-          </label>
-
-          <button
-            type="button"
-            onClick={handleAnalyze}
-            disabled={loading || !chordsInput.trim()}
-            className="w-full bg-primary-600 hover:bg-primary-700 disabled:bg-slate-300 disabled:cursor-not-allowed text-white font-semibold py-3 px-6 rounded-lg transition shadow-sm"
-          >
-            {loading ? 'Analyzing…' : 'Analyze progression'}
-          </button>
-        </div>
-      </SectionCard>
-
-      {/* Demo mode: Python API equivalent */}
-      {demoMode && (
-        <SectionCard
-          eyebrow="Python API"
-          title="Same call from your code"
-          subtitle="The library exposes the same engine under a small async surface"
-          action={<Tag tone="slate">demo</Tag>}
-        >
-          <pre className="text-xs sm:text-sm font-mono text-slate-800 bg-slate-50 p-4 rounded-lg overflow-x-auto border border-slate-200">
-{`from harmonic_analysis.services import PatternAnalysisService
-
-service = PatternAnalysisService()
-result = await service.analyze_with_patterns_async(
-    ['C', 'Am', 'F', 'G'],
-    profile="classical"
-)
-print(result.primary.key_signature)
-print(result.primary.roman_numerals)`}
-          </pre>
-        </SectionCard>
-      )}
-
-      {/* Error banner */}
-      {error && (
-        <SectionCard
-          eyebrow="Error"
-          title="Couldn't analyze that"
-          className="border-rose-200 bg-rose-50/50"
-        >
-          <p className="text-sm text-rose-800">{error}</p>
-        </SectionCard>
-      )}
-
-      {/* Results */}
-      {results && (
-        <AnalysisResults
-          results={results}
-          showEducational={showEducational}
-          chords={analyzedChords}
-        />
-      )}
-    </div>
+          )
+        }
+      />
+      <CodeModal
+        open={codeModalOpen}
+        initialTab="manual"
+        initialLang="py"
+        onClose={() => setCodeModalOpen(false)}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary

Replaces Tab 1's vertical-stack layout (intro → form → code → results) with the **Workbench** design from the [Tab 1 design handoff](https://github.com/sammywachtel/harmonic-analysis/blob/main/.local_docs/) (Proposal D). A 340-px input panel pins to the left edge of the viewport; the right column owns its own scroll and holds the full \`AnalysisResults\` block. The page itself stops scrolling — only the right column does — so the user can edit chords and re-analyze without losing track of where they are.

## What changed

- **New components** under \`demo/frontend/src/components/\`:
  - \`WorkbenchLayout.tsx\` — fixed-height two-column frame. Escapes the page's max-width chrome with negative margins and claims \`h-[calc(100vh-7.5rem)]\` to fill viewport below the header/tab strip.
  - \`InputPanel.tsx\` — title strip + scrollable form body + pinned action footer (Analyze button + "View as Python" link).
  - \`EmptyAnalysisState.tsx\` — dashed slate-300 card that vertically centers in the right column before any analysis runs.
  - \`CodeModal.tsx\` — centered ~680 px dialog with a 3 × 3 feature (Manual / Notation / Audio) × language (Python / CLI / curl) snippet matrix, copy-to-clipboard, JSX-tokenized Python syntax highlighting (no raw HTML injection), three-way dismiss (Escape / backdrop / ×), and body-scroll lock while open.
- **Modified** \`Tab1.tsx\` to compose those four components. Adds \`codeModalOpen\` state and a fourth quick-example chip (\`Mixolydian ♭VII → G F C G\`) per the design spec. The inline Python \`SectionCard\` is gone — that content lives in \`CodeModal\` now. The error banner moves into the right column above the empty/results content.
- **CHANGELOG.md** updated under \`[Unreleased]\`.

## What didn't change

Library code and APIs are untouched. This is purely a frontend layout/UX rewrite. No tests were added or removed.

## Test plan

- [x] \`npx tsc --noEmit -p tsconfig.app.json\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 67/67 vitest pass
- [x] \`npm run build\` — production bundle builds
- [x] Visual confirmation (screenshots): empty state centers correctly, analyzed state shows the input column staying fixed while the right column scrolls through summary → progression → key → confidence → notes → patterns, code modal opens centered with full \"Use this from code\" title, language toggle (PY/CLI/CURL) switches snippets, feature tab toggle (Manual/Notation/Audio) switches bodies, copy-to-clipboard works
- [ ] Reviewer to confirm at a tighter viewport (≤ 1280×720) — the workbench is height-aware so worth a sanity check on a short laptop

## Notes for the reviewer

- \`WorkbenchLayout\` uses \`-mt-8 -mx-6 h-[calc(100vh-7.5rem)]\` to escape \`Layout\`'s padding chrome. The 7.5 rem accounts for the 56 px sticky header plus the ~46 px tab strip. If that breathing space ever feels wrong, \`WorkbenchLayout.tsx\` line 24 is the one knob.
- Global \`Footer\` lives below the workbench area; on a typical laptop viewport it sits below the fold (intentional per the design's \"page itself does not scroll\" intent). Scroll the page proper to reach it.
- The Python highlighter in \`CodeModal\` walks tokens (comment → string → identifier → plain) into React nodes — no \`innerHTML\` escape hatch. Safe-by-construction for the snippet content.

Build: 10